### PR TITLE
[skin.confluence] v3.0.11

### DIFF
--- a/720p/DialogAudioDSPManager.xml
+++ b/720p/DialogAudioDSPManager.xml
@@ -114,43 +114,6 @@
 					<scrollspeed>0</scrollspeed>
 				</control>
 			</focusedlayout>
-			<content>
-				<item id="91">
-					<label>1. $LOCALIZE[15057]</label>
-					<label2>$LOCALIZE[15114]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">InputResampling</property>
-				</item>
-				<item id="92">
-					<label>2. $LOCALIZE[15058]</label>
-					<label2>$LOCALIZE[15113]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">Preprocessing</property>
-				</item>
-				<item id="93">
-					<label>3. $LOCALIZE[15059]</label>
-					<label2>$LOCALIZE[15115]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">Masterprocessing</property>
-				</item>
-				<item id="94">
-					<label>4. $LOCALIZE[15060]</label>
-					<label2>$LOCALIZE[15117]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">Postprocessing</property>
-				</item>
-				<item id="95">
-					<label>5. $LOCALIZE[15061]</label>
-					<label2>$LOCALIZE[15116]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">OutputResampling</property>
-				</item>
-			</content>
 		</control>
 		<control type="group">
 			<description>white borders and mode description</description>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="skin.confluence"
-  version="3.0.10"
+  version="3.0.11"
   name="Confluence"
   provider-name="Jezz_X, Team Kodi">
   <requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+[B]3.0.11[/B]
+
+- Updated settings layout
+- Remove the set of ADSP manager dialog list types, becomes done from Kodi itself
+
 [B]3.0.10[/B]
 
 - Updated global search

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -476,48 +476,7 @@ msgctxt "#31392"
 msgid "Arial based"
 msgstr ""
 
-#empty strings from id 31393 to 31399
-#Description Labels
-
-msgctxt "#31400"
-msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin · Set language and region · Change file listing options[CR]Set up a screensaver"
-msgstr ""
-
-msgctxt "#31401"
-msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library · Set video playback options · Change video listing options[CR]Set subtitle fonts"
-msgstr ""
-
-msgctxt "#31402"
-msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library · Set music playback options · Change music listing options[CR]Setup song submission"
-msgstr ""
-
-msgctxt "#31403"
-msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options · Configure slideshow"
-msgstr ""
-
-msgctxt "#31404"
-msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set various cities to collect weather information"
-msgstr ""
-
-#empty string with id 31405
-
-msgctxt "#31406"
-msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays · Configure audio output · Setup remote controls[CR]Set power saving options · Enable debugging · Setup master lock"
-msgstr ""
-
-#empty string with id 31407
-
-msgctxt "#31408"
-msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed add-ons · Browse for and install add-ons from kodi.tv[CR]Modify add-on settings"
-msgstr ""
-
-msgctxt "#31409"
-msgid "[B]CONFIGURE TV SETTINGS[/B][CR][CR]Change full screen info · Manage EPG data settings"
-msgstr ""
-
-msgctxt "#31410"
-msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of Kodi via UPnP and HTTP · Configure file sharing[CR]Enable Zeroconf · Configure AirPlay"
-msgstr ""
+#empty strings from id 31393 to 31410
 
 msgctxt "#31411"
 msgid "First run help..."


### PR DESCRIPTION
- Updated settings layout
- Remove the set of ADSP manager dialog list types, becomes done from
Kodi itself