### PR TITLE
[skin.confluence] v3.0.26

### DIFF
--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -39,8 +39,8 @@
 	<constant name="DepthSideBlade">0.15</constant>
 	<!-- VARIABLES -->
 	<variable name="AddonLabel2">
-		<value condition="!String.IsEmpty(ListItem.AddonSize)">$INFO[ListItem.AddonSize]</value>
 		<value condition="!String.IsEmpty(ListItem.Property(Addon.Status))">$INFO[ListItem.Property(Addon.Status)]</value>
+		<value condition="!String.IsEmpty(ListItem.AddonSize)">$INFO[ListItem.AddonSize]</value>
 	</variable>
 	<variable name="MusicInfoHeader">
 		<value condition="Container.Content(Artists)">$INFO[ListItem.Artist]</value>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="skin.confluence"
-  version="3.0.25"
+  version="3.0.26"
   name="Confluence"
   provider-name="Jezz_X, Team Kodi">
   <requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+[B]3.0.26[/B]
+
+- Show addon status if available, instead of size
+
 [B]3.0.25[/B]
 
 - Added size label to addon browser


### PR DESCRIPTION
- Show addon status if available, instead of size