### PR TITLE
[chg] codecinfo: conditionaly show pvr signal quality

### DIFF
--- a/720p/VideoOSD.xml
+++ b/720p/VideoOSD.xml
@@ -756,7 +756,7 @@
 		</control>
 		<control type="group">
 			<depth>DepthOSD+</depth>
-			<visible>Control.HasFocus(256) + VideoPlayer.Content(LiveTV)</visible>
+			<visible>Control.HasFocus(256) + VideoPlayer.Content(LiveTV) + system.getbool(pvrplayback.signalquality)</visible>
 			<left>640</left>
 			<top>40</top>
 			<control type="label">


### PR DESCRIPTION
^^

no point showing those values if pvrplayback.signalquality is false. as readings wont make any sense, anyway.