### PR TITLE
Videoplayer Fullscreen: display channel number and channel name + epis…

### DIFF
--- a/720p/VideoFullScreen.xml
+++ b/720p/VideoFullScreen.xml
@@ -117,7 +117,7 @@
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
 					<visible>![VideoPlayer.Content(LiveTV) + Player.Recording]</visible>
-					<animation effect="slide" start="0,0" end="0,25" time="0" condition="!VideoPlayer.Content(Movies) + !VideoPlayer.Content(Episodes) + !VideoPlayer.Content(MusicVideos) + !VideoPlayer.Content(LiveTV)">conditional</animation>
+					<animation effect="slide" start="0,0" end="0,25" time="0" condition="!VideoPlayer.Content(Movies) + !VideoPlayer.Content(Episodes) + !VideoPlayer.Content(MusicVideos) + !VideoPlayer.Content(LiveTV) + !PVR.IsPlayingRecording">conditional</animation>
 				</control>
 				<control type="image" id="1">
 					<top>0</top>
@@ -191,7 +191,7 @@
 					<label>$INFO[VideoPlayer.ChannelNumberLabel,([COLOR=blue],[/COLOR]) ]$INFO[VideoPlayer.ChannelName]$INFO[VideoPlayer.EpisodeName, (,)]</label>
 					<textcolor>grey2</textcolor>
 					<shadowcolor>black</shadowcolor>
-					<visible>VideoPlayer.Content(LiveTV)</visible>
+					<visible>VideoPlayer.Content(LiveTV) | PVR.IsPlayingRecording</visible>
 				</control>
 				<control type="grouplist" id="1">
 					<left>20</left>


### PR DESCRIPTION
…ode name for pvr recordings.

Once https://github.com/xbmc/xbmc/pull/10221 got merged, channel number, channel name and episode name will be displayed in video full screen info when playing a pvr recording, exactly like when playing a pvr channel:

![screenshot002](https://cloud.githubusercontent.com/assets/3226626/17360482/200a1784-596c-11e6-84d9-0aef0b1f7633.png)

@HitcherUK ping