### PR TITLE
Restore Video and Audio OSD sizes

### DIFF
--- a/720p/DialogSettings.xml
+++ b/720p/DialogSettings.xml
@@ -3,7 +3,7 @@
 	<defaultcontrol always="true">5</defaultcontrol>
 	<coordinates>
 		<left>240</left>
-		<top>142</top>
+		<top>50</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
@@ -13,7 +13,7 @@
 			<animation effect="fade" start="100" end="0" time="400" condition="Window.Is(osdaudiodspsettings) + Window.IsVisible(SliderDialog)">Conditional</animation>
 			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="800" />
-				<param name="DialogBackgroundHeight" value="458" />
+				<param name="DialogBackgroundHeight" value="625" />
 				<param name="DialogHeaderWidth" value="720" />
 				<param name="DialogHeaderId" value="2" />
 				<param name="CloseButtonLeft" value="710" />
@@ -23,9 +23,9 @@
 				<animation effect="slide" start="0,0" end="-10,0" time="0" condition="Control.IsVisible(60)">Conditional</animation>
 				<description>control area</description>
 				<left>35</left>
-				<top>70</top>
-				<width>730</width>
-				<height>308</height>
+				<top>60</top>
+				<width>720</width>
+				<height>495</height>
 				<itemgap>4</itemgap>
 				<pagecontrol>60</pagecontrol>
 				<onup>9001</onup>
@@ -34,10 +34,10 @@
 				<onright>60</onright>
 			</control>
 			<control type="scrollbar" id="60">
-				<left>758</left>
-				<top>70</top>
+				<left>760</left>
+				<top>55</top>
 				<width>25</width>
-				<height>308</height>
+				<height>500</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
 				<texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
 				<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
@@ -107,7 +107,7 @@
 			</control>
 			<control type="grouplist" id="9001">
 				<left>170</left>
-				<top>393</top>
+				<top>560</top>
 				<width>460</width>
 				<align>center</align>
 				<itemgap>20</itemgap>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.confluence" version="3.0.39" name="Confluence" provider-name="Jezz_X, Team Kodi">
+<addon id="skin.confluence" version="3.0.40" name="Confluence" provider-name="Jezz_X, Team Kodi">
 	<requires>
 		<import addon="xbmc.gui" version="5.12.0"/>
 	</requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,7 @@
 
 [B]3.0.36[/B]
 
-- Added customisable home submenus that use library nodes
+- Added customizable home submenus that use library nodes
 - Added news feature
 
 [B]3.0.35[/B]
@@ -46,11 +46,11 @@
 
 [B]3.0.29[/B]
 
-- Updated video osd player process info
+- Updated video OSD player process info
 
 [B]3.0.28[/B]
 
-- Added player processing info to video osd
+- Added player processing info to video OSD
 
 [B]3.0.27[/B]
 
@@ -58,15 +58,15 @@
 
 [B]3.0.26[/B]
 
-- Show addon status if available, instead of size
+- Show add-on status if available, instead of size
 
 [B]3.0.25[/B]
 
-- Added size label to addon browser
+- Added size label to add-on browser
 
 [B]3.0.24[/B]
 
-- Removed changelog button from addon info dialog
+- Removed changelog button from add-on info dialog
 
 [B]3.0.23[/B]
 
@@ -91,7 +91,7 @@
 
 [B]3.0.18[/B]
 
-- Fix text width for buttons in addon settings
+- Fix text width for buttons in add-on settings
 
 [B]3.0.17[/B]
 
@@ -322,7 +322,7 @@
 [B]2.1.0[/B]
 
 - Changed the home menu to Horizontal Layout instead of Vertical
-- Added support for the TvTunes Addon enable it in skin settings\General (if you have it installed)
+- Added support for the TvTunes Add-on enable it in skin settings\General (if you have it installed)
 - Added support for the Weather+ script (install it and select it in weather settings)
 - Updated translation files
 - Added some more codec flagging images (eg: pcm_bluray, wav files, etc)
@@ -336,7 +336,7 @@
 
 - All media views now follow a similar layout off File List on the Left hand side and icons/data on the right
 - Views are all now in content panels (no fullscreen black)
-- Added a thumb view for addons
+- Added a thumb view for add-ons
 - Non full screen Now Playing Media info (Bottom left) has more info
 - Full screen Now Playing Media info trimmed down
 - Fullscreen Player controls changed
@@ -350,7 +350,7 @@
 
 - Redesigned the video and Music OSD Info and controls
 - Added more images for codec flagging on videos and audio
-- Added all the windows needed for the new Addon Browser
+- Added all the windows needed for the new Add-on Browser
 - Removed the right hand side bar graphic from all windows and only made the left hand one visible if a menu is there
 - Lots of other little changes
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,13 @@
+[B]3.0.40[/B]
+
+- Restore settings dialog height
+
 [B]3.0.39[/B]
 
 - Fixed home Weather item
 - Added 'Privacy Policy' to system info
 - Updated background video conditions
+- Add numeric seek label
 
 [B]3.0.38[/B]
 


### PR DESCRIPTION
At some stage, the OSD Video and Audio dialog heights were cut in more or less half, this restores the height more or less.

Also bumped version and added changelog entries to match.
The last commit is just some cosmetic typo fixes to changelog file.

Current
![screenshot016](https://cloud.githubusercontent.com/assets/3521959/19889650/f125b190-a02d-11e6-8301-baaf29ebd5c1.png)
![screenshot017](https://cloud.githubusercontent.com/assets/3521959/19889651/f12a75cc-a02d-11e6-9272-3243705f557d.png)

Restored
![screenshot018](https://cloud.githubusercontent.com/assets/3521959/19889669/04259b66-a02e-11e6-8a3c-efe1658060a7.png)
![screenshot019](https://cloud.githubusercontent.com/assets/3521959/19889668/0424a120-a02e-11e6-8ba3-1d0998e75383.png)

Can an update of skin in mirrors happen at some stage, its quite behind atm.

@HitcherUK also bumped and added changelog, if you want this take it asap, idk how long I have left and I doubt theres internet where Im going.
