### PR TITLE
Remove secondary icon from Recordings list

### DIFF
--- a/720p/MyPVRRecordings.xml
+++ b/720p/MyPVRRecordings.xml
@@ -237,20 +237,9 @@
 			<control type="group">
 				<left>910</left>
 				<top>80</top>
-				<control type="image">
-					<left>10</left>
-					<top>0</top>
-					<width>290</width>
-					<height>230</height>
-					<aspectratio aligny="bottom">keep</aspectratio>
-					<fadetime>IconCrossfadeTime</fadetime>
-					<texture fallback="DefaultVideoCover.png">$INFO[Container(50).ListItem.Icon]</texture>
-					<bordertexture border="8">ThumbShadow.png</bordertexture>
-					<bordersize>8</bordersize>
-				</control>
 				<control type="fadelabel">
 					<left>10</left>
-					<top>230</top>
+					<top>0</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[Container(50).ListItem.Title]$INFO[ListItem.EpisodeName, (,)]</label>
@@ -265,9 +254,9 @@
 				<control type="textbox">
 					<description>Description Value for TV Show</description>
 					<left>10</left>
-					<top>272</top>
+					<top>40</top>
 					<width>290</width>
-					<height>223</height>
+					<height>455</height>
 					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>


### PR DESCRIPTION
Removes secondary icon from details in recordings list
- This provides more space for the plot and
- avoids a long-standing problem on RPi which causes scrolling the list to be painfully slow

Before:
![screenshot058](https://cloud.githubusercontent.com/assets/12870817/20650742/b7a06d48-b4cd-11e6-9616-370be921fb06.png)

After:
![screenshot057](https://cloud.githubusercontent.com/assets/12870817/20650736/8158cfaa-b4cd-11e6-9807-9434f61ba83e.png)
(note this image also includes the change in https://github.com/xbmc/skin.confluence/pull/22)