### PR TITLE
[fix] start / finishtime in fullscreen pvr osd

### DIFF
--- a/720p/VideoFullScreen.xml
+++ b/720p/VideoFullScreen.xml
@@ -349,7 +349,7 @@
 					<font>font13</font>
 					<align>left</align>
 					<aligny>center</aligny>
-					<label>$INFO[Player.StartTime(hh:mm)]</label>
+					<label>$INFO[Pvr.Time]</label>
 				</control>
 				<control type="progress" id="1">
 					<description>ProgressbarCache</description>
@@ -389,7 +389,7 @@
 					<font>font13</font>
 					<align>right</align>
 					<aligny>center</aligny>
-					<label>$INFO[Player.FinishTime(hh:mm)]</label>
+					<label>$INFO[Pvr.Duration]</label>
 				</control>
 			</control>
 		</control>


### PR DESCRIPTION
Player.* is useless for pvr. especialy Player.StartTime that returns
complete nonsense, use Pvr.Time / Pvr.Duration