### PR TITLE
[chg] add-ons/settings: adjust for xbmc/pull/12125

### DIFF
--- a/720p/DialogAddonSettings.xml
+++ b/720p/DialogAddonSettings.xml
@@ -1,190 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">9</defaultcontrol>
+	<defaultcontrol>5</defaultcontrol>
 	<coordinates>
 		<left>240</left>
-		<top>60</top>
+		<top>92</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<include content="DialogBackgroundCommons">
-			<param name="DialogBackgroundWidth" value="800" />
-			<param name="DialogBackgroundHeight" value="600" />
-			<param name="DialogHeaderWidth" value="720" />
-			<param name="DialogHeaderLabel" value="-" />
-			<param name="DialogHeaderId" value="20" />
-			<param name="CloseButtonLeft" value="710" />
-			<param name="CloseButtonNav" value="3" />
-		</include>
-		<control type="grouplist" id="9">
-			<description>button area</description>
-			<left>45</left>
-			<top>70</top>
-			<width>710</width>
-			<height>40</height>
-			<itemgap>5</itemgap>
-			<align>center</align>
-			<orientation>horizontal</orientation>
-			<onleft>9</onleft>
-			<onright>9</onright>
-			<onup>2</onup>
-			<ondown>2</ondown>
-		</control>
-		<control type="image">
-			<description>Has Previous</description>
-			<left>25</left>
-			<top>80</top>
-			<width>20</width>
-			<height>20</height>
-			<texture>scroll-left-focus.png</texture>
-			<visible>Container(9).HasPrevious</visible>
-		</control>
-		<control type="image">
-			<description>Has Next</description>
-			<left>755</left>
-			<top>80</top>
-			<width>20</width>
-			<height>20</height>
-			<texture>scroll-right-focus.png</texture>
-			<visible>Container(9).HasNext</visible>
-		</control>
-		<control type="grouplist" id="2">
-			<description>control area</description>
-			<left>40</left>
-			<top>120</top>
-			<width>720</width>
-			<height>380</height>
-			<itemgap>5</itemgap>
-			<pagecontrol>30</pagecontrol>
-			<onup>9</onup>
-			<ondown>9001</ondown>
-			<onleft>2</onleft>
-			<onright>30</onright>
-		</control>
-		<control type="scrollbar" id="30">
-			<left>765</left>
-			<top>120</top>
-			<width>25</width>
-			<height>380</height>
-			<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
-			<texturesliderbar border="2,16,2,16">ScrollBarV_bar.png</texturesliderbar>
-			<texturesliderbarfocus border="2,16,2,16">ScrollBarV_bar_focus.png</texturesliderbarfocus>
-			<textureslidernib>ScrollBarNib.png</textureslidernib>
-			<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
-			<onleft>2</onleft>
-			<onright>2</onright>
-			<showonepage>false</showonepage>
-			<orientation>vertical</orientation>
-		</control>
-		<control type="group" id="9001">
-			<top>535</top>
-			<left>90</left>
+		<control type="group">
+			<animation effect="fade" start="100" end="0" time="150" condition="Window.Is(contentsettings) + Window.IsActive(AddonSettings)">Conditional</animation>
+			<animation effect="fade" start="100" end="0" time="300" condition="[Window.Is(osdaudiosettings) | Window.Is(osdvideosettings)] + [Window.IsVisible(SliderDialog) | Window.IsVisible(OSDAudioDSPSettings) |  Window.IsVisible(FileBrowser)]">Conditional</animation>
+			<animation effect="fade" start="100" end="0" time="400" condition="Window.Is(osdaudiodspsettings) + Window.IsVisible(SliderDialog)">Conditional</animation>
+			<include content="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="800" />
+				<param name="DialogBackgroundHeight" value="508" />
+				<param name="DialogHeaderWidth" value="720" />
+				<param name="DialogHeaderId" value="2" />
+				<param name="CloseButtonLeft" value="710" />
+				<param name="CloseButtonNav" value="10" />
+			</include>
+			<control type="grouplist" id="3">
+				<description>Categories Area</description>
+				<left>45</left>
+				<top>70</top>
+				<width>710</width>
+				<height>40</height>
+				<orientation>horizontal</orientation>
+				<onleft>3</onleft>
+				<onright>3</onright>
+				<onup>9001</onup>
+				<ondown>5</ondown>
+				<align>center</align>
+			</control>
 			<control type="button" id="10">
-				<description>OK Button</description>
-				<left>0</left>
-				<top>0</top>
-				<width>200</width>
+				<description>Default Category Button</description>
+				<width>240</width>
 				<height>40</height>
+				<textoffsetx>20</textoffsetx>
 				<align>center</align>
 				<aligny>center</aligny>
-				<font>font12_title</font>
-				<label>186</label>
-				<onleft>12</onleft>
-				<onright>11</onright>
-				<onup>2</onup>
-				<ondown>2</ondown>
+				<font>font25_title</font>
+				<texturenofocus border="5">button-nofocus.png</texturenofocus>
+				<texturefocus border="5">button-focus.png</texturefocus>
 			</control>
-			<control type="button" id="11">
-				<description>Cancel Button</description>
-				<left>210</left>
-				<top>0</top>
-				<width>200</width>
+			<control type="image">
+				<description>Has Previous</description>
+				<left>25</left>
+				<top>80</top>
+				<width>20</width>
+				<height>20</height>
+				<texture>scroll-left-focus.png</texture>
+				<visible>Container(3).HasPrevious</visible>
+			</control>
+			<control type="image">
+				<description>Has Next</description>
+				<left>755</left>
+				<top>80</top>
+				<width>20</width>
+				<height>20</height>
+				<texture>scroll-right-focus.png</texture>
+				<visible>Container(3).HasNext</visible>
+			</control>
+			<control type="grouplist" id="5">
+				<animation effect="slide" start="0,0" end="-10,0" time="0" condition="Control.IsVisible(60)">Conditional</animation>
+				<description>control area</description>
+				<left>35</left>
+				<top>120</top>
+				<width>730</width>
+				<height>308</height>
+				<itemgap>4</itemgap>
+				<pagecontrol>60</pagecontrol>
+				<onup>3</onup>
+				<ondown>9001</ondown>
+				<onleft>60</onleft>
+				<onright>60</onright>
+			</control>
+			<control type="scrollbar" id="60">
+				<left>758</left>
+				<top>120</top>
+				<width>25</width>
+				<height>308</height>
+				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
+				<texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
+				<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
+				<textureslidernib>ScrollBarNib.png</textureslidernib>
+				<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
+				<onleft>5</onleft>
+				<onright>5</onright>
+				<ondown>60</ondown>
+				<onup>60</onup>
+				<showonepage>false</showonepage>
+				<orientation>vertical</orientation>
+			</control>
+			<control type="button" id="7">
+				<description>Default Button</description>
 				<height>40</height>
+				<font>font13</font>
+				<texturefocus border="5">button-focus2.png</texturefocus>
+			</control>
+			<control type="radiobutton" id="8">
+				<description>Default RadioButton</description>
+				<height>40</height>
+				<font>font13</font>
+				<texturefocus border="5">button-focus2.png</texturefocus>
+			</control>
+			<control type="spincontrolex" id="9">
+				<description>Default SpinControlex</description>
+				<height>40</height>
+				<font>font13</font>
+				<textcolor>grey2</textcolor>
+				<focusedcolor>white</focusedcolor>
+				<texturenofocus border="5">button-nofocus.png</texturenofocus>
+				<texturefocus border="5">button-focus2.png</texturefocus>
+				<aligny>center</aligny>
+				<reverse>yes</reverse>
+			</control>
+			<control type="image" id="11">
+				<description>separator image</description>
+				<height>2</height>
+				<texture>separator2.png</texture>
+			</control>
+			<control type="edit" id="12">
+				<description>Default Edit</description>
+				<height>40</height>
+				<font>font13</font>
+				<textcolor>grey2</textcolor>
+				<focusedcolor>white</focusedcolor>
+				<texturenofocus border="5">button-nofocus.png</texturenofocus>
+				<texturefocus border="5">button-focus2.png</texturefocus>
+			</control>
+			<control type="sliderex" id="13">
+				<description>Default Slider</description>
+				<height>40</height>
+				<texturenofocus border="5">button-nofocus.png</texturenofocus>
+				<texturefocus border="5">button-focus2.png</texturefocus>
+				<font>font13</font>
+				<textcolor>grey2</textcolor>
+				<focusedcolor>white</focusedcolor>
+			</control>
+			<control type="label" id="14">
+				<description>Default Heading</description>
+				<height>34</height>
+				<font>font12</font>
 				<align>center</align>
 				<aligny>center</aligny>
-				<font>font12_title</font>
-				<label>222</label>
-				<onleft>10</onleft>
-				<onright>12</onright>
-				<onup>2</onup>
-				<ondown>2</ondown>
+				<textcolor>blue</textcolor>
+				<shadowcolor>black</shadowcolor>
 			</control>
-			<control type="button" id="12">
-				<description>Defaults Button</description>
-				<left>420</left>
-				<top>0</top>
-				<width>200</width>
-				<height>40</height>
+			<control type="grouplist" id="9001">
+				<left>70</left>
+				<top>443</top>
+				<width>660</width>
 				<align>center</align>
-				<aligny>center</aligny>
-				<font>font12_title</font>
-				<label>409</label>
-				<onleft>11</onleft>
-				<onright>10</onright>
-				<onup>2</onup>
-				<ondown>2</ondown>
+				<itemgap>20</itemgap>
+				<orientation>horizontal</orientation>
+				<control type="button" id="28">
+					<description>OK Button</description>
+					<top>0</top>
+					<width>200</width>
+					<height>40</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12_title</font>
+					<onleft>30</onleft>
+					<onright>29</onright>
+					<onup>5</onup>
+					<ondown>5</ondown>
+				</control>
+				<control type="button" id="29">
+					<description>Cancel Button</description>
+					<top>0</top>
+					<width>200</width>
+					<height>40</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12_title</font>
+					<label/>
+					<onleft>28</onleft>
+					<onright>30</onright>
+					<onup>5</onup>
+					<ondown>5</ondown>
+				</control>
+				<control type="button" id="30">
+					<description>Settings Button</description>
+					<top>0</top>
+					<width>200</width>
+					<height>40</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12_title</font>
+					<onleft>29</onleft>
+					<onright>28</onright>
+					<onup>5</onup>
+					<ondown>5</ondown>
+				</control>
 			</control>
-		</control>
-		<control type="button" id="13">
-			<description>Default Category Button</description>
-			<height>40</height>
-			<width>173</width>
-			<align>center</align>
-			<aligny>center</aligny>
-			<font>font12_title</font>
-			<textcolor>white</textcolor>
-			<pulseonselect>false</pulseonselect>
-		</control>
-		<control type="button" id="3">
-			<description>Default Button</description>
-			<height>40</height>
-			<font>font13</font>
-			<textcolor>grey2</textcolor>
-			<focusedcolor>white</focusedcolor>
-			<texturefocus border="5">button-focus2.png</texturefocus>
-		</control>
-		<control type="radiobutton" id="4">
-			<description>Default RadioButton</description>
-			<height>40</height>
-			<font>font13</font>
-			<textwidth>668</textwidth>
-			<textcolor>grey2</textcolor>
-			<focusedcolor>white</focusedcolor>
-			<texturefocus border="5">button-focus2.png</texturefocus>
-		</control>
-		<control type="spincontrolex" id="5">
-			<description>Default spincontrolex</description>
-			<height>40</height>
-			<textcolor>grey2</textcolor>
-			<focusedcolor>white</focusedcolor>
-			<texturenofocus border="5">button-nofocus.png</texturenofocus>
-			<texturefocus border="5">button-focus2.png</texturefocus>
-			<font>font13</font>
-			<aligny>center</aligny>
-			<reverse>yes</reverse>
-		</control>
-		<control type="label" id="7">
-			<height>35</height>
-			<font>font13_title</font>
-			<label></label>
-			<textcolor>blue</textcolor>
-			<shadowcolor>black</shadowcolor>
-			<align>left</align>
-			<aligny>center</aligny>
-		</control>
-		<control type="image" id="6">
-			<description>Default Seperator</description>
-			<height>2</height>
-			<texture>separator2.png</texture>
-		</control>
-		<control type="sliderex" id="8">
-			<description>Default Slider</description>
-			<height>40</height>
-			<font>font13</font>
-			<textwidth>518</textwidth>
-			<textcolor>grey2</textcolor>
-			<focusedcolor>white</focusedcolor>
-			<texturefocus border="5">button-focus2.png</texturefocus>
 		</control>
 	</controls>
 </window>


### PR DESCRIPTION
a poor attempt to make addon settings work after https://github.com/xbmc/xbmc/pull/12125

this needs testing, I am really bad at skinning and not sure I am doing the positioning right

DialogAddonSettings.xml is now basicaly same as DialogSettings.xml with some small changes:

- control id 9001 is re-positioned to fit the new "defaults" button.
- added conrtols for categories area on top.

here is the diff http://sprunge.us/PgVa