### PR TITLE
Navigating down from the "Home" window's menu should take you directly to "Favorites"

### DIFF
--- a/720p/Home.xml
+++ b/720p/Home.xml
@@ -1067,14 +1067,14 @@
 		<control type="group" id="9002">
 			<depth>DepthMenu</depth>
 			<onup>9001</onup>
-			<ondown>20</ondown>
+			<ondown>21</ondown>
 			<control type="fixedlist" id="700">
 				<animation effect="slide" start="0,0" end="-91,0" time="0" condition="String.IsEqual(Container(700).NumItems,2) | String.IsEqual(Container(700).NumItems,4)">conditional</animation>
 				<visible>Container(9000).HasFocus(2) | Container(9000).HasFocus(10) | Container(9000).HasFocus(11)</visible>
 				<onleft>700</onleft>
 				<onright>700</onright>
 				<onup>9001</onup>
-				<ondown>20</ondown>
+				<ondown>21</ondown>
 				<include>HomeAddonsCommonLayout</include>
 				<content>
 					<include>HomeAddonItemsVideos</include>
@@ -1086,7 +1086,7 @@
 				<onleft>703</onleft>
 				<onright>703</onright>
 				<onup>9001</onup>
-				<ondown>20</ondown>
+				<ondown>21</ondown>
 				<include>HomeAddonsCommonLayout</include>
 				<content>
 					<include>HomeAddonItemsMusic</include>
@@ -1098,7 +1098,7 @@
 				<onleft>704</onleft>
 				<onright>704</onright>
 				<onup>9001</onup>
-				<ondown>20</ondown>
+				<ondown>21</ondown>
 				<include>HomeAddonsCommonLayout</include>
 				<content>
 					<include>HomeAddonItemsPictures</include>
@@ -1110,7 +1110,7 @@
 				<onleft>705</onleft>
 				<onright>705</onright>
 				<onup>9001</onup>
-				<ondown>20</ondown>
+				<ondown>21</ondown>
 				<include>HomeAddonsCommonLayout</include>
 				<content>
 					<include>HomeAddonItemsPrograms</include>


### PR DESCRIPTION
Currently, when users navigate down from the main menu items in the ```Home``` window, the active control becomes the ```Power``` button.  Accessing the favorites requires one more navigation to the left.  I think it's much more likely that users would want quick and direct access to their ```Favorites``` (hence the name), rather than quick and direct access to shut down their home theater software.

This pull request modified [Home.xml](../blob/master/720p/Home.xml) to allow navigation directly to the favorites button from the main menu items.

