### PR TITLE
Recognize NR as Not Rated for mpaa tag

### DIFF
--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -464,6 +464,7 @@
 		<value condition="String.Contains(listitem.mpaa,Rated PG)">mpaa_pg</value>
 		<value condition="String.Contains(Listitem.mpaa,Rated R)">mpaa_restricted</value>
 		<value condition="String.Contains(Listitem.mpaa,Rated NC)">mpaa_nc17</value>
+		<value condition="String.Contains(Listitem.mpaa,Rated NR)">mpaa_notrated</value>
 		<value condition="String.Contains(Listitem.mpaa,Not Rated)">mpaa_notrated</value>
 	</variable>
 	<variable name="videocodec">


### PR DESCRIPTION
The Default movie scraper (TMDB) uses 'NR' for Not Rated movies. This change fixes the tag recognition.