### PR TITLE
add conditional shortcut for LibreELEC settings

### DIFF
--- a/720p/IncludesHomeMenuItems.xml
+++ b/720p/IncludesHomeMenuItems.xml
@@ -198,6 +198,12 @@
 			<label>5</label>
 			<onclick>ActivateWindow(Settings)</onclick>
 		</control>
+		<control type="button" id="90120">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>LibreELEC</label>
+			<onclick>RunAddon(service.libreelec.settings)</onclick>
+			<visible>System.HasAddon(service.libreelec.settings)</visible>
+		</control>
 		<control type="button" id="90123">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>7</label>


### PR DESCRIPTION
LE 7.0 (and OE before) patched an extra tab under Settings on the homescreen to facilitate easier access to our settings/configuration add-on, e.g. 

https://github.com/LibreELEC/LibreELEC.tv/blob/libreelec-7.0/packages/mediacenter/kodi-theme-Confluence/patches/kodi-theme-Confluence-001-add_oe_settings_to_homescreen.patch

Users who update to LE 8.0/9.0 and install the repo version of Confluence often cannot find the settings add-on under Add-ons > Program Add-on's or they just moan about this shortcut not being present. So this PR adds it back, but conditionally, like how we add a link in Estuary:

https://github.com/phil65/skin.estuary/blob/master/xml/Settings.xml#L114-L119