### PR TITLE
[skin.confluence] Fix LiveTV with EPG elapsed time and duration

### DIFF
--- a/720p/DialogPVRInfo.xml
+++ b/720p/DialogPVRInfo.xml
@@ -198,6 +198,12 @@
 				<label>19003</label>
 				<visible>Window.IsActive(PVRGuideInfo)</visible>
 			</control>
+			<control type="button" id="10">
+				<description>Play programme</description>
+				<include>ButtonInfoDialogsCommonValues</include>
+				<label>19190</label>
+				<visible>Window.IsActive(PVRGuideInfo)</visible>
+			</control>
 			<control type="button" id="5">
 				<description>Switch to Channel</description>
 				<include>ButtonInfoDialogsCommonValues</include>

--- a/720p/DialogSeekBar.xml
+++ b/720p/DialogSeekBar.xml
@@ -250,61 +250,123 @@
 				<textcolor>blue</textcolor>
 				<label>$VAR[SeekLabel]</label>
 			</control>
-			<control type="label">
-				<description>Elapsed Time Label</description>
-				<left>20</left>
-				<top>23</top>
-				<width>240</width>
-				<height>20</height>
-				<font>font13_title</font>
-				<textcolor>white</textcolor>
-				<align>left</align>
-				<aligny>center</aligny>
-				<label>$INFO[Player.Time] - $INFO[Player.Duration]</label>
-				<visible>!Player.Seeking</visible>
+			<control type="group">
+				<visible>[VideoPlayer.Content(LiveTV) + VideoPlayer.HasEpg]</visible>
+				<control type="label">
+					<description>Elapsed Time Label</description>
+					<left>20</left>
+					<top>23</top>
+					<width>240</width>
+					<height>20</height>
+					<font>font13_title</font>
+					<textcolor>white</textcolor>
+					<align>left</align>
+					<aligny>center</aligny>
+					<label>$INFO[PVR.EpgEventElapsedTime] - $INFO[PVR.EpgEventDuration]</label>
+					<visible>!Player.Seeking</visible>
+				</control>
+				<control type="label">
+					<description>Seek Time Label</description>
+					<left>20</left>
+					<top>23</top>
+					<width>240</width>
+					<height>20</height>
+					<font>font13_title</font>
+					<textcolor>white</textcolor>
+					<align>left</align>
+					<aligny>center</aligny>
+					<label>$INFO[PVR.EpgEventSeekTime] - $INFO[PVR.EpgEventDuration]</label>
+					<visible>Player.Seeking</visible>
+				</control>
+				<control type="progress">
+					<description>ProgressbarTimeshift</description>
+					<left>20</left>
+					<top>45</top>
+					<width>240</width>
+					<height>15</height>
+					<info>PVR.TimeshiftProgressBufferEnd </info>
+					<midtexture border="6,0,6,0">OSDProgressMidLight.png</midtexture>
+					<visible>PVR.IsTimeShift</visible>
+				</control>
+				<control type="progress" id="23">
+					<description>Progressbar</description>
+					<left>20</left>
+					<top>45</top>
+					<width>240</width>
+					<height>15</height>
+					<info>PVR.EpgEventProgress</info>
+					<visible>true</visible>
+				</control>
+				<control type="slider" id="403">
+					<description>Seek Slider</description>
+					<left>20</left>
+					<top>42</top>
+					<width>240</width>
+					<height>12</height>
+					<texturesliderbar>seekslider.png</texturesliderbar>
+					<textureslidernib>osd_slider_nib.png</textureslidernib>
+					<textureslidernibfocus>osd_slider_nib.png</textureslidernibfocus>
+					<visible>Player.Seeking</visible>
+				</control>
 			</control>
-			<control type="label">
-				<description>Seek Time Label</description>
-				<left>20</left>
-				<top>23</top>
-				<width>240</width>
-				<height>20</height>
-				<font>font13_title</font>
-				<textcolor>white</textcolor>
-				<align>left</align>
-				<aligny>center</aligny>
-				<label>$INFO[Player.SeekTime] - $INFO[Player.Duration]</label>
-				<visible>Player.Seeking</visible>
-			</control>
-			<control type="progress">
-				<description>ProgressbarCache</description>
-				<left>20</left>
-				<top>45</top>
-				<width>240</width>
-				<height>15</height>
-				<info>Player.ProgressCache</info>
-				<midtexture border="6,0,6,0">OSDProgressMidLight.png</midtexture>
-				<visible>true</visible>
-			</control>
-			<control type="progress" id="23">
-				<description>Progressbar</description>
-				<left>20</left>
-				<top>45</top>
-				<width>240</width>
-				<height>15</height>
-				<info>Player.Progress</info>
-				<visible>true</visible>
-			</control>
-			<control type="slider" id="401">
-				<description>Seek Slider</description>
-				<left>20</left>
-				<top>42</top>
-				<width>240</width>
-				<height>12</height>
-				<texturesliderbar>seekslider.png</texturesliderbar>
-				<textureslidernib>osd_slider_nib.png</textureslidernib>
-				<textureslidernibfocus>osd_slider_nib.png</textureslidernibfocus>
-				<visible>Player.Seeking</visible>
+			<control type="group">
+				<visible>![VideoPlayer.Content(LiveTV) + VideoPlayer.HasEpg]</visible>
+				<control type="label">
+					<description>Elapsed Time Label</description>
+					<left>20</left>
+					<top>23</top>
+					<width>240</width>
+					<height>20</height>
+					<font>font13_title</font>
+					<textcolor>white</textcolor>
+					<align>left</align>
+					<aligny>center</aligny>
+					<label>$INFO[Player.Time] - $INFO[Player.Duration]</label>
+					<visible>!Player.Seeking</visible>
+				</control>
+				<control type="label">
+					<description>Seek Time Label</description>
+					<left>20</left>
+					<top>23</top>
+					<width>240</width>
+					<height>20</height>
+					<font>font13_title</font>
+					<textcolor>white</textcolor>
+					<align>left</align>
+					<aligny>center</aligny>
+					<label>$INFO[Player.SeekTime] - $INFO[Player.Duration]</label>
+					<visible>Player.Seeking</visible>
+				</control>
+				<control type="progress">
+					<description>ProgressbarCache</description>
+					<left>20</left>
+					<top>45</top>
+					<width>240</width>
+					<height>15</height>
+					<info>Player.ProgressCache</info>
+					<midtexture border="6,0,6,0">OSDProgressMidLight.png</midtexture>
+					<visible>true</visible>
+				</control>
+				<control type="progress" id="23">
+					<description>Progressbar</description>
+					<left>20</left>
+					<top>45</top>
+					<width>240</width>
+					<height>15</height>
+					<info>Player.Progress</info>
+					<visible>true</visible>
+				</control>
+				<control type="slider" id="401">
+					<description>Seek Slider</description>
+					<left>20</left>
+					<top>42</top>
+					<width>240</width>
+					<height>12</height>
+					<texturesliderbar>seekslider.png</texturesliderbar>
+					<textureslidernib>osd_slider_nib.png</textureslidernib>
+					<textureslidernibfocus>osd_slider_nib.png</textureslidernibfocus>
+					<visible>Player.Seeking</visible>
+				</control>
 			</control>
 		</control>
 	</controls>

--- a/720p/Home.xml
+++ b/720p/Home.xml
@@ -361,6 +361,21 @@
 					<font>font12</font>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
+					<visible>!VideoPlayer.HasEpg</visible>
+				</control>
+				<control type="label">
+					<description>Time Label</description>
+					<left>160</left>
+					<top>310</top>
+					<height>30</height>
+					<width>300</width>
+					<label>$INFO[PVR.EpgEventElapsedTime]$INFO[PVR.EpgEventDuration,[COLOR=blue] / [/COLOR]]</label>
+					<align>left</align>
+					<aligny>center</aligny>
+					<font>font12</font>
+					<textcolor>white</textcolor>
+					<shadowcolor>black</shadowcolor>
+					<visible>VideoPlayer.HasEpg</visible>
 				</control>
 			</control>
 			<control type="group">

--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -439,6 +439,11 @@
 		<value condition="!String.IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
+	<variable name="NowPlayingThumb">
+		<value condition="!String.IsEmpty(Player.Art(poster))">$INFO[Player.Art(poster)]</value>
+		<value condition="!String.IsEmpty(Player.Art(tvshow.poster))">$INFO[Player.Art(tvshow.poster)]</value>
+		<value>$INFO[Player.Icon]</value>
+	</variable>
 	<variable name="MusicInfoPanelLabel">
 		<value condition="Container.Content(Artists)">$INFO[ListItem.Label]</value>
 		<value condition="Container.Content(Songs)">$INFO[ListItem.Label,[COLOR=selected][B],[/B][/COLOR] - ]$INFO[ListItem.Label2]</value>

--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -882,6 +882,20 @@
 				<font>font12</font>
 				<textcolor>grey</textcolor>
 				<shadowcolor>black</shadowcolor>
+				<visible>!VideoPlayer.HasEpg | !VideoPlayer.Content(LiveTV)</visible>
+			</control>
+			<control type="label">
+				<left>85</left>
+				<top>53r</top>
+				<width>700</width>
+				<height>20</height>
+				<label>$INFO[Player.Title] - ([COLOR=blue]$INFO[PVR.EpgEventElapsedTime] / $INFO[PVR.EpgEventDuration,][/COLOR])</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey</textcolor>
+				<shadowcolor>black</shadowcolor>
+				<visible>VideoPlayer.HasEpg + VideoPlayer.Content(LiveTV)</visible>
 			</control>
 			<control type="label">
 				<left>85</left>

--- a/720p/VideoFullScreen.xml
+++ b/720p/VideoFullScreen.xml
@@ -363,13 +363,27 @@
 					<top>120</top>
 					<width>910</width>
 					<height>25</height>
-					<label>$INFO[VideoPlayer.NextTitle,$LOCALIZE[19031]: ]</label>
+					<label>$INFO[VideoPlayer.NextTitle,[B]$LOCALIZE[19031]: [/B]]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<font>font12</font>
 					<textcolor>grey</textcolor>
 					<scroll>true</scroll>
 					<visible>!Window.IsVisible(VideoOSD) + VideoPlayer.Content(LiveTV)</visible>
+					<animation effect="fade" time="150">VisibleChange</animation>
+				</control>
+				<control type="label" id="1">
+					<left>0</left>
+					<top>150</top>
+					<width>910</width>
+					<height>25</height>
+					<label>[B]$LOCALIZE[31961][/B] $INFO[PVR.TimeshiftCur] (-$INFO[PVR.TimeshiftOffset])</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12</font>
+					<textcolor>grey</textcolor>
+					<scroll>true</scroll>
+					<visible>!Window.IsVisible(VideoOSD) + VideoPlayer.Content(LiveTV) + PVR.IsTimeShift</visible>
 					<animation effect="fade" time="150">VisibleChange</animation>
 				</control>
 			</control>

--- a/720p/VideoFullScreen.xml
+++ b/720p/VideoFullScreen.xml
@@ -119,7 +119,7 @@
 				<top>260r</top>
 				<width>300</width>
 				<height>230</height>
-				<texture fallback="DefaultVideoCover.png">$INFO[Player.Art(thumb)]</texture>
+				<texture fallback="DefaultVideoCover.png">$VAR[NowPlayingThumb]</texture>
 				<aspectratio aligny="bottom">keep</aspectratio>
 				<bordertexture border="8">ThumbShadow.png</bordertexture>
 				<bordersize>8</bordersize>

--- a/720p/VideoFullScreen.xml
+++ b/720p/VideoFullScreen.xml
@@ -397,25 +397,49 @@
 					<font>font13</font>
 					<align>left</align>
 					<aligny>center</aligny>
-					<label>$INFO[Player.StartTime(hh:mm)]</label>
+					<label>$INFO[VideoPlayer.StartTime]</label>
 				</control>
-				<control type="progress" id="1">
-					<description>ProgressbarCache</description>
-					<left>100</left>
-					<top>15</top>
-					<width>720</width>
-					<height>16</height>
-					<info>Player.ProgressCache</info>
-					<midtexture border="6,0,6,0">OSDProgressMidLight.png</midtexture>
-					<visible>!Player.ChannelPreviewActive</visible>
+				<control type="group" id="1">
+					<visible>VideoPlayer.Content(LiveTV)</visible>
+					<control type="progress" id="1">
+						<description>ProgressbarTimeshift</description>
+						<left>100</left>
+						<top>15</top>
+						<width>720</width>
+						<height>16</height>
+						<info>PVR.TimeshiftProgressBufferEnd</info>
+						<midtexture border="6,0,6,0">OSDProgressMidLight.png</midtexture>
+						<visible>PVR.IsTimeShift</visible>
+					</control>
+					<control type="progress" id="1">
+						<description>Progressbar</description>
+						<left>100</left>
+						<top>15</top>
+						<width>720</width>
+						<height>16</height>
+						<info>PVR.EpgEventProgress</info>
+					</control>
 				</control>
-				<control type="progress" id="1">
-					<description>Progressbar</description>
-					<left>100</left>
-					<top>15</top>
-					<width>720</width>
-					<height>16</height>
-					<info>Player.Progress</info>
+				<control type="group" id="1">
+					<visible>!VideoPlayer.Content(LiveTV)</visible>
+					<control type="progress" id="1">
+						<description>ProgressbarCache</description>
+						<left>100</left>
+						<top>15</top>
+						<width>720</width>
+						<height>16</height>
+						<info>Player.ProgressCache</info>
+						<midtexture border="6,0,6,0">OSDProgressMidLight.png</midtexture>
+						<visible>!Player.ChannelPreviewActive</visible>
+					</control>
+					<control type="progress" id="1">
+						<description>Progressbar</description>
+						<left>100</left>
+						<top>15</top>
+						<width>720</width>
+						<height>16</height>
+						<info>Player.Progress</info>
+					</control>
 				</control>
 				<control type="label" id="1">
 					<visible>!VideoPlayer.Content(LiveTV)</visible>
@@ -437,7 +461,7 @@
 					<font>font13</font>
 					<align>right</align>
 					<aligny>center</aligny>
-					<label>$INFO[Player.FinishTime(hh:mm)]</label>
+					<label>$INFO[VideoPlayer.EndTime]</label>
 				</control>
 			</control>
 		</control>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -688,3 +688,7 @@ msgstr ""
 msgctxt "#31960"
 msgid "RADIO"
 msgstr ""
+
+msgctxt "#31961"
+msgid "Timeshift"
+msgstr ""


### PR DESCRIPTION
This PR fixes incorrectly displayed times when playing LiveTV content with EPG.
Before the fix, incorrect time/duration was displayed while seeking/timeshifting, progress bars did not work.
Incorrect start time and end time was displayed in full video screen, PVR Info and Home screens.