### PR TITLE
[skin.confluence] Fix multiline AddonNews from spanning over everyting

### DIFF
--- a/720p/DialogAddonInfo.xml
+++ b/720p/DialogAddonInfo.xml
@@ -155,18 +155,30 @@
 					<font>font13</font>
 					<textcolor>blue</textcolor>
 				</control>
-				<control type="fadelabel">
+				<control type="spincontrol" id="60">
+					<description>Next page button</description>
+					<left>550</left>
+					<top>120</top>
+					<subtype>page</subtype>
+					<font></font>
+					<ondown>9000</ondown>
+					<onup>9000</onup>
+					<textcolor></textcolor>
+					<showonepage>true</showonepage>
+					<visible>!String.IsEmpty(ListItem.AddonNews)</visible>
+				</control>
+				<control type="textbox">
 					<description>News Value</description>
 					<left>160</left>
 					<top>120</top>
-					<width>440</width>
+					<width>310</width>
 					<height>25</height>
 					<label fallback="416">$INFO[ListItem.AddonNews]</label>
 					<align>left</align>
 					<aligny>center</aligny>
 					<font>font13</font>
-					<scrollout>false</scrollout>
-					<pauseatend>2000</pauseatend>
+					<pagecontrol>60</pagecontrol>
+					<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
 				</control>
 				<control type="image">
 					<left>0</left>


### PR DESCRIPTION
This PR fixes the issue with long AddonNews sections. Before the fix it would span over all of the elements in the window (see screenshot). This PR replaces fadelabel with textbox with autoscrolling and a page up/down button. A more thorough solution would be a button text box with scrolling that opens a new window, similar to Estuary.
![confluence-addonnew-issue](https://user-images.githubusercontent.com/502466/46256611-aa4b8200-c4b5-11e8-8eae-b76e68f45919.png)