### PR TITLE
New "Now playing" view aligned to "Media Info"

### DIFF
--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -859,7 +859,7 @@
 	</include>
 	<include name="CommonNowPlaying">
 		<control type="group">
-			<visible>Player.HasMedia + String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))</visible>
+			<visible>Player.HasMedia + String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia)) + !Control.IsVisible(507)</visible>
 			<include>VisibleFadeEffect</include>
 			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
 			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>

--- a/720p/IncludesBackgroundBuilding.xml
+++ b/720p/IncludesBackgroundBuilding.xml
@@ -130,7 +130,7 @@
 			</control>
 			<control type="group">
 				<include>VisibleFadeEffect</include>
-				<visible>Control.IsVisible(551) | Control.IsVisible(560) | Control.IsVisible(511) | Control.IsVisible(506) | Control.IsVisible(513)</visible>
+				<visible>Control.IsVisible(551) | Control.IsVisible(560) | Control.IsVisible(511) | Control.IsVisible(506) | Control.IsVisible(507) | Control.IsVisible(513)</visible>
 				<control type="image">
 					<left>50</left>
 					<top>60</top>

--- a/720p/MyMusicNav.xml
+++ b/720p/MyMusicNav.xml
@@ -3,7 +3,7 @@
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
-	<views>50,51,500,550,551,509,506,511,512,513</views>
+	<views>50,51,500,550,551,509,506,507,511,512,513</views>
 	<controls>
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
@@ -17,6 +17,8 @@
 			<include>ThumbnailView</include>
 			<!-- view id = 506 -->
 			<include>MusicInfoListView</include>
+			<!-- view id = 507 -->
+			<include>NowPlaying</include>
 			<!-- view id = 509 -->
 			<include>AlbumWrapView2_Fanart</include>
 			<!-- view id = 511 -->

--- a/720p/MyPlaylist.xml
+++ b/720p/MyPlaylist.xml
@@ -3,7 +3,7 @@
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
-	<views>50,51,506</views>
+	<views>50,51,506,507</views>
 	<controls>
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
@@ -15,6 +15,8 @@
 			<include>FullWidthList</include>
 			<!-- view id = 506 -->
 			<include>MusicInfoListView</include>
+			<!-- view id = 507 -->
+			<include>NowPlaying</include>
 		</control>
 		<control type="group">
 			<depth>DepthFooter</depth>
@@ -26,11 +28,11 @@
 		<include>ScrollOffsetLabel</include>
 		<include content="CommonWindowHeader" condition="Window.IsActive(videoplaylist)">
 			<param name="Icon" value="icon_video" />
-			<param name="Label" value="$LOCALIZE[10522]" />
+			<param name="Label" value="$LOCALIZE[31059] - $LOCALIZE[14215]" />
 		</include>
 		<include content="CommonWindowHeader" condition="Window.IsActive(musicplaylist)">
 			<param name="Icon" value="icon_music" />
-			<param name="Label" value="$LOCALIZE[10517]" />
+			<param name="Label" value="$LOCALIZE[31059] - $LOCALIZE[14216]" />
 		</include>
 		<control type="group">
 			<left>-250</left>

--- a/720p/ViewsMusicLibrary.xml
+++ b/720p/ViewsMusicLibrary.xml
@@ -123,9 +123,20 @@
 				<visible>Control.IsVisible(506)</visible>
 				<left>910</left>
 				<top>80</top>
-				<control type="image">
+				<control type="label">
 					<left>10</left>
 					<top>0</top>
+					<width>290</width>
+					<height>20</height>
+					<label>$LOCALIZE[544]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font13</font>
+					<textcolor>white</textcolor>
+				</control>
+				<control type="image">
+					<left>10</left>
+					<top>20</top>
 					<width>290</width>
 					<height>290</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
@@ -136,14 +147,14 @@
 				</control>
 				<control type="label">
 					<left>10</left>
-					<top>300</top>
+					<top>315</top>
 					<width>290</width>
-					<height>25</height>
-					<label>$INFO[ListItem.Artist]</label>
+					<height>45</height>
+					<label>$INFO[listitem.TrackNumber,,. ]$INFO[ListItem.Title]</label>
+					<wrapmultiline>true</wrapmultiline>
 					<scroll>true</scroll>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font24_title</font>
+					<align>left</align>
+					<font>font13_title</font>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
 				</control>
@@ -151,95 +162,295 @@
 					<left>10</left>
 					<top>360</top>
 					<width>290</width>
-					<height>25</height>
-					<label>$INFO[ListItem.Album]</label>
+					<height>45</height>
+					<label>$INFO[listitem.Artist]</label>
 					<wrapmultiline>true</wrapmultiline>
-					<align>center</align>
-					<aligny>center</aligny>
+					<scroll>true</scroll>
+					<align>left</align>
+					<font>font13_title</font>
+					<textcolor>white</textcolor>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="image">
+					<left>10</left>
+					<top>415</top>
+					<width>168</width>
+					<height>20</height>
+					<texture fallback="ratings/0.png">$INFO[ListItem.Rating,ratings/,.png]</texture>
+				</control>
+				<control type="label">
+					<left>10</left>
+					<top>440</top>
+					<width>290</width>
+					<height>45</height>
+					<label>$INFO[ListItem.Album]$INFO[ListItem.DiscNumber, - Disc ]</label>
+					<wrapmultiline>true</wrapmultiline>
+					<scroll>false</scroll>
+					<scrolltime>200</scrolltime>
+					<align>left</align>
 					<font>font13</font>
 					<textcolor>grey2</textcolor>
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
 					<left>10</left>
-					<top>420</top>
+					<top>485</top>
 					<width>290</width>
-					<height>25</height>
-					<label>$INFO[ListItem.Title]</label>
-					<scroll>true</scroll>
-					<align>center</align>
-					<aligny>top</aligny>
-					<font>font13_title</font>
-					<textcolor>white</textcolor>
+					<height>20</height>
+					<label>$INFO[listitem.Year,, | ]$INFO[ListItem.Genre]</label>
+					<wrapmultiline>true</wrapmultiline>
+					<scroll>false</scroll>
+					<scrolltime>200</scrolltime>
+					<align>left</align>
+					<font>font13</font>
+					<textcolor>grey2</textcolor>
 					<shadowcolor>black</shadowcolor>
 					<wrapmultiline>true</wrapmultiline>
-					<visible>!Container.Content(Albums)</visible>
 				</control>
 				<control type="label">
-					<left>10</left>
-					<top>420</top>
-					<width>290</width>
-					<height>25</height>
-					<label>$INFO[ListItem.Genre]</label>
-					<scroll>true</scroll>
-					<align>center</align>
-					<aligny>top</aligny>
-					<font>font13_title</font>
-					<textcolor>white</textcolor>
-					<shadowcolor>black</shadowcolor>
-					<wrapmultiline>true</wrapmultiline>
-					<visible>Container.Content(Albums)</visible>
-				</control>
-				<control type="label">
-					<description>Trackno txt</description>
-					<left>10</left>
-					<top>480</top>
-					<width>290</width>
-					<height>25</height>
-					<label>$INFO[listitem.TrackNumber,[COLOR=blue]$LOCALIZE[31310]: [/COLOR]]</label>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<textcolor>white</textcolor>
-					<visible>!Container.Content(Albums)</visible>
-				</control>
-				<control type="label">
-					<description>Year txt</description>
-					<left>10</left>
-					<top>505</top>
-					<width>290</width>
-					<height>25</height>
-					<label>$INFO[listitem.Year,[COLOR=blue]$LOCALIZE[345]: [/COLOR]]</label>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<textcolor>white</textcolor>
-				</control>
-				<control type="label">
-					<description>Rating txt</description>
 					<left>10</left>
 					<top>530</top>
 					<width>290</width>
-					<height>25</height>
-					<label>$INFO[ListItem.Rating,[COLOR=blue]$LOCALIZE[563]: [/COLOR]]</label>
+					<height>20</height>
+					<label>$LOCALIZE[180]: $INFO[ListItem.Duration(mm:ss)]</label>
+					<align>left</align>
+					<font>font13</font>
+					<textcolor>white</textcolor>
+				</control>
+			</control>
+		</control>
+	</include>
+	<include name="NowPlaying">
+		<control type="group">
+			<visible>Control.IsVisible(507)</visible>
+			<include>VisibleFadeEffect</include>
+			<control type="list" id="507">
+				<left>70</left>
+				<top>75</top>
+				<width>780</width>
+				<height>561</height>
+				<onleft>2</onleft>
+				<onright>60</onright>
+				<onup>507</onup>
+				<ondown>507</ondown>
+				<viewtype label="$LOCALIZE[31040]">list</viewtype>
+				<pagecontrol>60</pagecontrol>
+				<scrolltime>200</scrolltime>
+				<visible>Window.IsVisible(MusicPlaylist) | Window.IsVisible(10502)</visible>
+				<itemlayout height="40" width="780">
+					<control type="image">
+						<left>0</left>
+						<top>0</top>
+						<width>780</width>
+						<height>41</height>
+						<texture border="0,2,0,2">MenuItemNF.png</texture>
+					</control>
+					<control type="label">
+						<left>10</left>
+						<top>0</top>
+						<width>730</width>
+						<height>40</height>
+						<font>font13</font>
+						<textcolor>grey2</textcolor>
+						<selectedcolor>selected</selectedcolor>
+						<align>left</align>
+						<aligny>center</aligny>
+						<label>$INFO[ListItem.Label]</label>
+					</control>
+					<control type="label">
+						<left>60</left>
+						<top>0</top>
+						<width>700</width>
+						<height>40</height>
+						<font>font12</font>
+						<textcolor>grey2</textcolor>
+						<selectedcolor>selected</selectedcolor>
+						<align>right</align>
+						<aligny>center</aligny>
+						<label>$INFO[ListItem.Label2]</label>
+					</control>
+				</itemlayout>
+				<focusedlayout height="40" width="760">
+					<control type="image">
+						<left>0</left>
+						<top>0</top>
+						<width>760</width>
+						<height>41</height>
+						<texture border="0,2,0,2">MenuItemNF.png</texture>
+						<visible>!Control.HasFocus(507)</visible>
+						<include>VisibleFadeEffect</include>
+					</control>
+					<control type="image">
+						<left>0</left>
+						<top>0</top>
+						<width>780</width>
+						<height>41</height>
+						<texture border="0,2,0,2">MenuItemFO.png</texture>
+						<visible>Control.HasFocus(507)</visible>
+						<include>VisibleFadeEffect</include>
+					</control>
+					<control type="image">
+						<left>580</left>
+						<top>5</top>
+						<width>200</width>
+						<height>31</height>
+						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
+						<visible>Control.HasFocus(507) + !String.IsEmpty(ListItem.Label2)</visible>
+					</control>
+					<control type="label">
+						<left>10</left>
+						<top>0</top>
+						<width>730</width>
+						<height>40</height>
+						<font>font13</font>
+						<textcolor>white</textcolor>
+						<selectedcolor>selected</selectedcolor>
+						<align>left</align>
+						<aligny>center</aligny>
+						<label>$INFO[ListItem.Label]</label>
+					</control>
+					<control type="label">
+						<left>60</left>
+						<top>0</top>
+						<width>700</width>
+						<height>40</height>
+						<font>font12</font>
+						<textcolor>grey2</textcolor>
+						<selectedcolor>selected</selectedcolor>
+						<align>right</align>
+						<aligny>center</aligny>
+						<label>$INFO[ListItem.Label2]</label>
+					</control>
+				</focusedlayout>
+			</control>
+			<control type="scrollbar" id="60">
+				<left>850</left>
+				<top>78</top>
+				<width>25</width>
+				<height>560</height>
+				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
+				<texturesliderbar border="2,16,2,16">ScrollBarV_bar.png</texturesliderbar>
+				<texturesliderbarfocus border="2,16,2,16">ScrollBarV_bar_focus.png</texturesliderbarfocus>
+				<textureslidernib>ScrollBarNib.png</textureslidernib>
+				<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
+				<onleft>506</onleft>
+				<onright>2</onright>
+				<showonepage>false</showonepage>
+				<orientation>vertical</orientation>
+				<visible>Control.IsVisible(507)</visible>
+			</control>
+			<control type="group">
+				<visible>Control.IsVisible(507)</visible>
+				<left>910</left>
+				<top>80</top>
+				<control type="label">
+					<left>10</left>
+					<top>0</top>
+					<width>290</width>
+					<height>20</height>
+					<label>$LOCALIZE[31040]</label>
+					<visible>!Player.HasAudio</visible>
 					<align>center</align>
 					<aligny>center</aligny>
 					<font>font13</font>
 					<textcolor>white</textcolor>
-					<visible>Container.Content(Albums)</visible>
 				</control>
 				<control type="label">
-					<description>UserRating txt</description>
+					<left>10</left>
+					<top>0</top>
+					<width>290</width>
+					<height>20</height>
+					<label>$LOCALIZE[31040]$INFO[musicplayer.Playlistposition,: ]$INFO[musicplayer.Playlistlength,/]</label>
+					<visible>Player.HasAudio</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font13</font>
+					<textcolor>white</textcolor>
+				</control>
+				<control type="image">
+					<left>10</left>
+					<top>20</top>
+					<width>290</width>
+					<height>290</height>
+					<aspectratio aligny="bottom">keep</aspectratio>
+					<fadetime>IconCrossfadeTime</fadetime>
+					<texture background="true">$INFO[Player.Art(thumb)]</texture>
+					<bordertexture border="8">ThumbShadow.png</bordertexture>
+					<bordersize>8</bordersize>
+				</control>
+				<control type="label">
+					<left>10</left>
+					<top>315</top>
+					<width>290</width>
+					<height>45</height>
+					<label>$INFO[MusicPlayer.Title]</label>
+					<wrapmultiline>true</wrapmultiline>
+					<scroll>true</scroll>
+					<align>left</align>
+					<font>font13_title</font>
+					<textcolor>white</textcolor>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<left>10</left>
+					<top>360</top>
+					<width>290</width>
+					<height>45</height>
+					<label>$INFO[MusicPlayer.Artist]</label>
+					<wrapmultiline>true</wrapmultiline>
+					<scroll>true</scroll>
+					<align>left</align>
+					<font>font13_title</font>
+					<textcolor>white</textcolor>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="image">
+					<left>10</left>
+					<top>415</top>
+					<width>168</width>
+					<height>20</height>
+					<texture fallback="ratings/0.png">$INFO[MusicPlayer.UserRating,ratings/,.png]</texture>
+					<visible>Player.HasAudio</visible>
+				</control>
+				<control type="label">
+					<left>10</left>
+					<top>440</top>
+					<width>290</width>
+					<height>45</height>
+					<label>$INFO[MusicPlayer.Album]$INFO[MusicPlayer.DiscNumber, - Disc ]</label>
+					<wrapmultiline>true</wrapmultiline>
+					<scroll>false</scroll>
+					<scrolltime>200</scrolltime>
+					<align>left</align>
+					<font>font13</font>
+					<textcolor>grey2</textcolor>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<left>10</left>
+					<top>485</top>
+					<width>290</width>
+					<height>20</height>
+					<label>$INFO[MusicPlayer.Year,, | ]$INFO[MusicPlayer.Genre]</label>
+					<wrapmultiline>true</wrapmultiline>
+					<scroll>false</scroll>
+					<scrolltime>200</scrolltime>
+					<align>left</align>
+					<font>font13</font>
+					<textcolor>grey2</textcolor>
+					<shadowcolor>black</shadowcolor>
+					<wrapmultiline>true</wrapmultiline>
+				</control>
+				<control type="label">
 					<left>10</left>
 					<top>530</top>
 					<width>290</width>
-					<height>25</height>
-					<label>$INFO[ListItem.UserRating,[COLOR=blue]$LOCALIZE[38018]: [/COLOR]]</label>
-					<align>center</align>
-					<aligny>center</aligny>
+					<height>20</height>
+					<label>$LOCALIZE[31016]: $INFO[Player.Time(mm:ss]$INFO[Player.Duration(mm:ss),/]</label>
+					<align>left</align>
 					<font>font13</font>
 					<textcolor>white</textcolor>
-					<visible>Container.Content(Songs)</visible>
+					<visible>Player.HasAudio</visible>
 				</control>
 			</control>
 		</control>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -88,7 +88,11 @@ msgctxt "#31015"
 msgid "Minute"
 msgstr ""
 
-#empty strings from id 31016 to 31022
+msgctxt "#31016"
+msgid "Elapsed time"
+msgstr ""
+
+#empty strings from id 31017 to 31022
 
 msgctxt "#31023"
 msgid "Playing"


### PR DESCRIPTION
Users want to be able to view playlist and for the currently playing track details to be shown, the present Media Info view only shows the details of the selected track.

The design for the new "Now playing" view was based on the existing "Media info" view with some modifcations:

![now_playing](https://user-images.githubusercontent.com/5781142/46571138-b462fa00-c967-11e8-8139-c58273d90e1b.JPG)

The existing "Media info" then was aligned for a match in style:

![new_media_info](https://user-images.githubusercontent.com/5781142/46571150-f8ee9580-c967-11e8-8781-fb0cea6b1ee3.JPG)

For comparison old "Media info"

![old_media_info](https://user-images.githubusercontent.com/5781142/46571151-073cb180-c968-11e8-88fc-97b119b40878.JPG)

**Implementation notes**

- As the design of "Media info" and "Now playing" matches then the info box is titled so you easily know which view you are in.

- With old "Media info" view if the text was too long then it would scroll, with both new "Media info" and "Now Playing" I've given enough room to wrap to 2 lines for long text string as shown by artist name and track title in above images.

- Rather than restrict this "Now Playing " view to only the Playlist window, I've allowed it to be selected throughout the music windows so you can keep track on the now playing details if you are browsing through music collection. For example:

![now_playing2](https://user-images.githubusercontent.com/5781142/46571219-09534000-c969-11e8-996a-aebdd070a3dc.JPG)
