### PR TITLE
Restore home weather icon

### DIFF
--- a/720p/Home.xml
+++ b/720p/Home.xml
@@ -1253,7 +1253,7 @@
 					<width>60</width>
 					<height>60</height>
 					<aspectratio>keep</aspectratio>
-					<texture>$INFO[Weather.Conditions]</texture>
+					<texture>$INFO[Weather.ConditionsIcon]</texture>
 				</control>
 				<control type="label">
 					<description>Location label</description>


### PR DESCRIPTION
According to GUIInfoManager.cpp, Weather.Conditions returns "Current weather conditions as textual description". So, to show a weather icon on the upper left of the home screen this must be changed with weather.ConditionsIcon