### PR TITLE
Add setting for profile identification

### DIFF
--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -534,6 +534,11 @@
 		<value condition="ListItem.HasTimer + !ListItem.TimerIsActive">$LOCALIZE[19057]</value>
 		<value condition="ListItem.HasTimer">$LOCALIZE[31510]</value>
 	</variable>
+	<variable name="ProfileIdentificationLabel2Var">
+		<value condition="Skin.HasSetting(show_profilename)">$LOCALIZE[31963]</value>
+		<value condition="Skin.HasSetting(show_profileavatar)">$LOCALIZE[31964]</value>
+		<value>$LOCALIZE[16018]</value>
+	</variable>
 	<!-- INCLUDES -->
 	<include name="MusicInfoPanel">
 		<control type="panel" id="50">
@@ -1496,6 +1501,34 @@
 			<label>$INFO[System.Time]</label>
 			<animation effect="slide" start="0,0" end="-40,0" time="75" condition="Player.Muted">conditional</animation>
 		</control>
+                <control type="group">
+                        <visible>Integer.IsGreater(System.ProfileCount,1)</visible>
+                        <control type="image">
+                                <visible>Skin.HasSetting(show_profileavatar)</visible>
+                                <top>5</top>
+                                <left>1105</left>
+                                <width>30</width>
+                                <height>30</height>
+                                <animation effect="slide" start="0,0" end="-40,0" time="75" condition="Player.Muted">conditional</animation>
+                                <texture>$INFO[System.ProfileThumb]</texture>
+                                <aspectratio>scale</aspectratio>
+                        </control>
+                        <control type="label">
+                                <visible>Skin.HasSetting(show_profilename)</visible>
+                                <font>font28_title</font>
+                                <align>right</align>
+                                <top>5</top>
+                                <left>540</left>
+                                <textcolor>white</textcolor>
+                                <shadowcolor>black</shadowcolor>
+                                <aligny>center</aligny>
+                                <height>30</height>
+                                <width max="600">auto</width>
+                                <animation effect="slide" start="0,0" end="-40,0" time="75" condition="Player.Muted">conditional</animation>
+                                <label>$INFO[System.ProfileName]</label>
+                        </control>
+                </control>
+
 	</include>
 	<include name="HomeAddonsCommonLayout">
 		<include>Window_OpenClose_Animation</include>

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -269,6 +269,18 @@
 						<onclick>Skin.ToggleSetting(HideEPGwithRDS)</onclick>
 						<selected>Skin.HasSetting(HideEPGwithRDS)</selected>
 					</control>
+					<control type="button" id="117">
+                                                <width>750</width>
+                                                <height>40</height>
+                                                <font>font13</font>
+                                                <label>31962</label>
+                                                <textcolor>grey2</textcolor>
+                                                <focusedcolor>white</focusedcolor>
+                                                <texturefocus>MenuItemFO.png</texturefocus>
+                                                <texturenofocus>MenuItemNF.png</texturenofocus>
+						<onclick>Skin.SelectBool(31962, 31963|show_profilename, 31964|show_profileavatar, 16018|show_none)</onclick>
+						<label2>$VAR[ProfileIdentificationLabel2Var]</label2>
+					</control>
 				</control>
 				<control type="scrollbar" id="60">
 					<left>1060</left>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -701,3 +701,22 @@ msgstr ""
 msgctxt "#31961"
 msgid "Timeshift"
 msgstr ""
+
+#. Choose profile identifier
+#: /720p/SkinSettings.xml
+msgctxt "#31962"
+msgid "Choose kind of profile identification"
+msgstr ""
+
+#. Label for the kind of profile identification
+#: /720p/SkinSettings.xml
+msgctxt "#31963"
+msgid "Profile name"
+msgstr ""
+
+#. Label for the kind of profile identification
+#: /720p/SkinSettings.xml
+msgctxt "#31964"
+msgid "Profile avatar"
+msgstr ""
+


### PR DESCRIPTION
As we already have that at Estuary: https://github.com/xbmc/xbmc/pull/14007

I thought adding that for Confluence might also be a pretty good idea. 

I've tested what happens if Kodi gets mutet and the name as well as the avatar moving to the left for the muting icon.

If some music is playing, the location of the currently playing track is different from Estuary. It's not at the top, it's nearly in the middle of the screen. So neither the clock nor the profile identifiert is affected. 

Let me know if something needs to be changed. 