### PR TITLE
Fix missing label localisation

### DIFF
--- a/720p/ViewsMusicLibrary.xml
+++ b/720p/ViewsMusicLibrary.xml
@@ -183,7 +183,7 @@
 					<top>440</top>
 					<width>290</width>
 					<height>45</height>
-					<label>$INFO[ListItem.Album]$INFO[ListItem.DiscNumber, - Disc ]</label>
+					<label>$INFO[ListItem.Album]$INFO[ListItem.DiscNumber, - $LOCALIZE[427] ]</label>
 					<wrapmultiline>true</wrapmultiline>
 					<scroll>false</scroll>
 					<scrolltime>200</scrolltime>
@@ -417,7 +417,7 @@
 					<top>440</top>
 					<width>290</width>
 					<height>45</height>
-					<label>$INFO[MusicPlayer.Album]$INFO[MusicPlayer.DiscNumber, - Disc ]</label>
+					<label>$INFO[MusicPlayer.Album]$INFO[MusicPlayer.DiscNumber, - $LOCALIZE[427] ]</label>
 					<wrapmultiline>true</wrapmultiline>
 					<scroll>false</scroll>
 					<scrolltime>200</scrolltime>


### PR DESCRIPTION
In the PR38 Disc was hard labelled and I forgot to change it to a localised label.