### PR TITLE
Add 'End time' control and visibility

### DIFF
--- a/720p/DialogSeekBar.xml
+++ b/720p/DialogSeekBar.xml
@@ -9,6 +9,45 @@
 	<depth>DepthOSD</depth>
 	<controls>
 		<control type="group">
+			<visible>Window.IsVisible(FullscreenVideo) + ![Player.HasGame | VideoPlayer.HasEpg]</visible>
+			<left>850r</left>
+			<top>-6</top>
+			<include>VisibleFadeEffect</include>
+			<control type="image">
+				<left>0</left>
+				<top>0</top>
+				<width>150</width>
+				<height>70</height>
+				<colordiffuse>EEFFFFFF</colordiffuse>
+				<texture border="12">OverlayDialogBackground.png</texture>
+			</control>
+			<control type="label" id="1">
+				<description>End time label</description>
+				<left>20</left>
+				<top>10</top>
+				<width>110</width>
+				<height>20</height>
+				<align>center</align>
+				<aligny>center</aligny>
+				<font>font12_title</font>
+				<textcolor>blue</textcolor>
+				<scroll>true</scroll>
+				<label>$LOCALIZE[31049]</label>
+			</control>
+			<control type="label" id="1">
+				<description>End time from infolabel</description>
+				<left>20</left>
+				<top>30</top>
+				<width>110</width>
+				<height>20</height>
+				<align>center</align>
+				<aligny>center</aligny>
+				<font>font13_title</font>
+				<textcolor>grey2</textcolor>
+				<label>$INFO[Player.FinishTime]</label>
+			</control>
+		</control>
+		<control type="group">
 			<visible>player.chaptercount + Window.IsVisible(FullScreenVideo)</visible>
 			<left>705r</left>
 			<top>-6</top>

--- a/720p/VideoFullScreen.xml
+++ b/720p/VideoFullScreen.xml
@@ -339,7 +339,7 @@
 					<font>font12</font>
 					<textcolor>grey</textcolor>
 					<scroll>true</scroll>
-					<visible>!Window.IsVisible(VideoOSD) + !VideoPlayer.Content(LiveTV)</visible>
+					<visible>Window.IsVisible(VideoOSD) + !VideoPlayer.Content(LiveTV)</visible>
 					<animation effect="fade" time="150">VisibleChange</animation>
 				</control>
 				<control type="label" id="1">


### PR DESCRIPTION
The changes at "DialogSeekBar.xml" introducing an additional section showing the end time of a video at the top of a screen if the player is paused/seeking/etc and the videoOSD is not shown.

The changes at "FullScreenVideo.xml" is a typo fix, where I would say this happened by accident.

Open for comments and suggestions ;)

Screenshot:

![conf1](https://user-images.githubusercontent.com/7235787/54085660-a7946900-4340-11e9-9e96-fe3cc58b446f.png)
