### PR TITLE
Add add-ons submenu

### DIFF
--- a/720p/Home.xml
+++ b/720p/Home.xml
@@ -877,6 +877,14 @@
 					<!-- Buttons for the grouplist -->
 					<include>HomeSubMenuRadio</include>
 				</control>
+				<control type="grouplist" id="9017">
+					<include>HomeSubMenuCommonValues</include>
+					<onleft>9017</onleft>
+					<onright>9017</onright>
+					<visible>Container(9000).HasFocus(1)</visible>
+					<!--Buttons for the grouplist -->
+					<include>HomeSubMenuAddons</include>
+				</control>
 			</control>
 			<control type="image">
 				<left>-100</left>

--- a/720p/IncludesHomeMenuItems.xml
+++ b/720p/IncludesHomeMenuItems.xml
@@ -356,6 +356,38 @@
 			<texture border="0,0,0,3">HomeSubEnd.png</texture>
 		</control>
 	</include>
+	<include name="HomeSubMenuAddons">
+		<control type="image" id="90301">
+			<width>35</width>
+			<height>35</height>
+			<texture border="0,0,0,3" flipx="true">HomeSubEnd.png</texture>
+		</control>
+		<control type="button" id="90302">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>24998</label>
+			<onclick>ActivateWindow(addonbrowser,addons://user,return)</onclick>
+		</control>
+		<control type="button" id="90303">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>24033</label>
+			<onclick>ActivateWindow(addonbrowser,addons://repos/,return)</onclick>
+		</control>
+		<control type="button" id="90304">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>24041</label>
+			<onclick>InstallFromZip</onclick>
+		</control>
+		<control type="button" id="90305">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>137</label>
+			<onclick>ActivateWindow(addonbrowser,addons://search,return)</onclick>
+		</control>
+		<control type="image" id="90306">
+			<width>35</width>
+			<height>35</height>
+			<texture border="0,0,0,3">HomeSubEnd.png</texture>
+		</control>
+	</include>
 	<include name="HomeAddonItemsVideos">
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeVideosButton1))]</label>


### PR DESCRIPTION
I know, we talked about it and some ppl didn't like it, but here is what I have had already done and I thought it's worth PRing it

This change adds a submenu for the add-ons home menu entry and also probably kind of fixes #50 or probably gives less confusion. 

![conf2](https://user-images.githubusercontent.com/7235787/54089071-2f8c6a00-4365-11e9-941b-c0f212b79a78.png)
