### PR TITLE
Fix endtime visibility for video info screen

### DIFF
--- a/720p/VideoFullScreen.xml
+++ b/720p/VideoFullScreen.xml
@@ -339,7 +339,7 @@
 					<font>font12</font>
 					<textcolor>grey</textcolor>
 					<scroll>true</scroll>
-					<visible>Window.IsVisible(VideoOSD) + !VideoPlayer.Content(LiveTV)</visible>
+					<visible>[Player.ShowInfo | Window.IsVisible(VideoOSD)] + !VideoPlayer.Content(LiveTV)</visible>
 					<animation effect="fade" time="150">VisibleChange</animation>
 				</control>
 				<control type="label" id="1">


### PR DESCRIPTION
As we spoke about that at forums: 

https://forum.kodi.tv/showthread.php?tid=342673&pid=2844077#pid2844077

and at slack, this is the fix to show the endtime of a video at the video-info screen.

![grafik](https://user-images.githubusercontent.com/7235787/55852070-c3677680-5b5b-11e9-9149-3670f11c4c11.png)
