### PR TITLE
View layout changes

### DIFF
--- a/720p/ViewsVideoLibrary.xml
+++ b/720p/ViewsVideoLibrary.xml
@@ -146,18 +146,30 @@
 				<aligny>center</aligny>
 				<label>$INFO[ListItem.Year]</label>
 			</control>
-			<control type="label">
-				<left>0</left>
-				<top>580</top>
+			<control type="grouplist">
+				<left>10</left>
+				<top>570</top>
 				<width>1280</width>
-				<height>20</height>
-				<font>font13</font>
-				<textcolor>white</textcolor>
-				<shadowcolor>black</shadowcolor>
-				<scroll>true</scroll>
 				<align>center</align>
-				<aligny>center</aligny>
-				<label>$INFO[ListItem.Duration,$LOCALIZE[2050] , $LOCALIZE[12391]]</label>
+				<orientation>horizontal</orientation>
+				<itemgap>2</itemgap>
+				<control type="label">
+					<width>150</width>
+					<align>right</align>
+					<font>font13</font>
+					<textcolor>blue</textcolor>
+					<shadowcolor>black</shadowcolor>
+					<label>$LOCALIZE[180]: </label>
+					<visible>!ListItem.IsParentFolder</visible>
+				</control>
+				<control type="label">
+					<width>150</width>
+					<align>left</align>
+					<font>font13</font>
+					<textcolor>white</textcolor>
+					<shadowcolor>black</shadowcolor>
+					<label>$INFO[ListItem.Duration]</label>
+				</control>
 			</control>
 			<control type="grouplist">
 				<description>Media Codec Flagging Images</description>
@@ -1418,78 +1430,81 @@
 					<height>4</height>
 					<texture>separator.png</texture>
 				</control>
-				<control type="label">
-					<description>Year txt</description>
-					<left>-20</left>
-					<top>335</top>
-					<width>140</width>
-					<height>25</height>
-					<label>$LOCALIZE[345]:</label>
-					<align>right</align>
-					<aligny>center</aligny>
-					<font>font13_title</font>
-					<textcolor>blue</textcolor>
-				</control>
-				<control type="label">
-					<description>Year Value</description>
-					<left>130</left>
-					<top>335</top>
-					<width>340</width>
-					<height>25</height>
-					<label fallback="10005">$INFO[listitem.Year]</label>
-					<align>left</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<scroll>true</scroll>
-				</control>
-				<control type="label">
-					<description>Duration txt</description>
-					<left>180</left>
-					<top>335</top>
-					<width>140</width>
-					<height>25</height>
-					<label>$LOCALIZE[180]:</label>
-					<align>right</align>
-					<aligny>center</aligny>
-					<font>font13_title</font>
-					<textcolor>blue</textcolor>
-				</control>
-				<control type="label">
-					<description>Duration Value</description>
-					<left>330</left>
-					<top>335</top>
-					<width>100</width>
-					<height>25</height>
-					<label fallback="416">$INFO[listitem.Duration]</label>
-					<align>left</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<scroll>true</scroll>
-				</control>
-				<control type="label">
-					<description>Genre txt</description>
-					<left>-20</left>
-					<top>360</top>
-					<width>140</width>
-					<height>25</height>
-					<label>$LOCALIZE[515]:</label>
-					<align>right</align>
-					<aligny>center</aligny>
-					<font>font13_title</font>
-					<textcolor>blue</textcolor>
-				</control>
-				<control type="fadelabel">
-					<description>Genre Value</description>
-					<left>130</left>
-					<top>360</top>
-					<width>340</width>
-					<height>25</height>
-					<label fallback="10005">$INFO[listitem.Genre]</label>
-					<align>left</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<scrollout>false</scrollout>
-					<pauseatend>1000</pauseatend>
+				<control type="group">
+					<visible>!ListItem.IsParentFolder</visible>
+					<control type="label">
+						<description>Year txt</description>
+						<left>-20</left>
+						<top>335</top>
+						<width>140</width>
+						<height>25</height>
+						<label>$LOCALIZE[345]:</label>
+						<align>right</align>
+						<aligny>center</aligny>
+						<font>font13_title</font>
+						<textcolor>blue</textcolor>
+					</control>
+					<control type="label">
+						<description>Year Value</description>
+						<left>130</left>
+						<top>335</top>
+						<width>340</width>
+						<height>25</height>
+						<label fallback="10005">$INFO[listitem.Year]</label>
+						<align>left</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<scroll>true</scroll>
+					</control>
+					<control type="label">
+						<description>Duration txt</description>
+						<left>260</left>
+						<top>335</top>
+						<width>100</width>
+						<height>25</height>
+						<label>$LOCALIZE[180]:</label>
+						<align>right</align>
+						<aligny>center</aligny>
+						<font>font13_title</font>
+						<textcolor>blue</textcolor>
+					</control>
+					<control type="label">
+						<description>Duration Value</description>
+						<left>370</left>
+						<top>335</top>
+						<width>100</width>
+						<height>25</height>
+						<label fallback="416">$INFO[listitem.Duration]</label>
+						<align>left</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<scroll>true</scroll>
+					</control>
+					<control type="label">
+						<description>Genre txt</description>
+						<left>-20</left>
+						<top>360</top>
+						<width>140</width>
+						<height>25</height>
+						<label>$LOCALIZE[515]:</label>
+						<align>right</align>
+						<aligny>center</aligny>
+						<font>font13_title</font>
+						<textcolor>blue</textcolor>
+					</control>
+					<control type="fadelabel">
+						<description>Genre Value</description>
+						<left>130</left>
+						<top>360</top>
+						<width>340</width>
+						<height>25</height>
+						<label fallback="10005">$INFO[listitem.Genre]</label>
+						<align>left</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<scrollout>false</scrollout>
+						<pauseatend>1000</pauseatend>
+					</control>
 				</control>
 				<control type="image">
 					<left>0</left>
@@ -1548,78 +1563,81 @@
 					<height>4</height>
 					<texture>separator.png</texture>
 				</control>
-				<control type="label">
-					<description>Aired txt</description>
-					<left>10</left>
-					<top>335</top>
-					<width>140</width>
-					<height>25</height>
-					<label>$LOCALIZE[31322]:</label>
-					<align>right</align>
-					<aligny>center</aligny>
-					<font>font13_title</font>
-					<textcolor>blue</textcolor>
-				</control>
-				<control type="label">
-					<description>Aired Value</description>
-					<left>160</left>
-					<top>335</top>
-					<width>80</width>
-					<height>25</height>
-					<label fallback="10005">$INFO[listitem.Premiered]</label>
-					<align>left</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<scroll>true</scroll>
-				</control>
-				<control type="label">
-        <description>Duration txt</description>
-					<left>220</left>
-					<top>335</top>
-					<width>100</width>
-					<height>25</height>
-					<label>$LOCALIZE[180]:</label>
-					<align>right</align>
-					<aligny>center</aligny>
-					<font>font13_title</font>
-					<textcolor>blue</textcolor>
-				</control>
-				<control type="label">
-					<description>Duration Value</description>
-					<left>330</left>
-					<top>335</top>
-					<width>120</width>
-					<height>25</height>
-					<label fallback="416">$INFO[listitem.Duration]</label>
-					<align>left</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<scroll>true</scroll>
-				</control>
-				<control type="label">
-					<description>Episode txt</description>
-					<left>10</left>
-					<top>360</top>
-					<width>140</width>
-					<height>25</height>
-					<label>$LOCALIZE[20359]:</label>
-					<align>right</align>
-					<aligny>center</aligny>
-					<font>font13_title</font>
-					<textcolor>blue</textcolor>
-				</control>
-				<control type="fadelabel">
-					<description>Episode Value</description>
-					<left>160</left>
-					<top>360</top>
-					<width>340</width>
-					<height>25</height>
-					<label fallback="10005">$INFO[listitem.Season,,x]$INFO[listitem.Episode]</label>
-					<align>left</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<scrollout>false</scrollout>
-					<pauseatend>1000</pauseatend>
+				<control type="group">
+					<visible>!ListItem.IsParentFolder</visible>
+					<control type="label">
+						<description>Aired txt</description>
+						<left>10</left>
+						<top>335</top>
+						<width>140</width>
+						<height>25</height>
+						<label>$LOCALIZE[31322]:</label>
+						<align>right</align>
+						<aligny>center</aligny>
+						<font>font13_title</font>
+						<textcolor>blue</textcolor>
+					</control>
+					<control type="label">
+						<description>Aired Value</description>
+						<left>160</left>
+						<top>335</top>
+						<width>110</width>
+						<height>25</height>
+						<label fallback="10005">$INFO[listitem.Premiered]</label>
+						<align>left</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<scroll>true</scroll>
+					</control>
+					<control type="label">
+						<description>Duration txt</description>
+						<left>260</left>
+						<top>335</top>
+						<width>100</width>
+						<height>25</height>
+						<label>$LOCALIZE[180]:</label>
+						<align>right</align>
+						<aligny>center</aligny>
+						<font>font13_title</font>
+						<textcolor>blue</textcolor>
+					</control>
+					<control type="label">
+						<description>Duration Value</description>
+						<left>370</left>
+						<top>335</top>
+						<width>120</width>
+						<height>25</height>
+						<label fallback="416">$INFO[listitem.Duration]</label>
+						<align>left</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<scroll>true</scroll>
+					</control>
+					<control type="label">
+						<description>Episode txt</description>
+						<left>10</left>
+						<top>360</top>
+						<width>140</width>
+						<height>25</height>
+						<label>$LOCALIZE[20359]:</label>
+						<align>right</align>
+						<aligny>center</aligny>
+						<font>font13_title</font>
+						<textcolor>blue</textcolor>
+					</control>
+					<control type="fadelabel">
+						<description>Episode Value</description>
+						<left>160</left>
+						<top>360</top>
+						<width>340</width>
+						<height>25</height>
+						<label fallback="10005">$INFO[listitem.Season,,x]$INFO[listitem.Episode]</label>
+						<align>left</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<scrollout>false</scrollout>
+						<pauseatend>1000</pauseatend>
+					</control>
 				</control>
 				<control type="image">
 					<left>0</left>


### PR DESCRIPTION
I added the video duration to the PosterWrapView. It was there before, but in a different look. I made it compliant to #55:

![grafik](https://user-images.githubusercontent.com/7235787/62086228-f72af100-b25d-11e9-9dd9-184f9a2e9178.png)

Also added a visible condition to make the duration invisible if the "Parent Folder" is focused (thanks @HitcherUK for the hint ;) )

As I merged #55 myself and I have missed to test every scenario, I also changed a little bit of the alignment and the position of the duration-label at the MediaInfoView for movies and episodes as especially for episodes there was an overlap for the aired and the duration labels: 

![grafik](https://user-images.githubusercontent.com/7235787/62086437-994ad900-b25e-11e9-8242-5547f102b0fd.png)

The changes for the other sections are more to set the duration label at the same position and also make them invisible if the "Parent Folder"-item was selected.

![grafik](https://user-images.githubusercontent.com/7235787/62086581-18401180-b25f-11e9-9f08-6c0d1946d5af.png)


Hope this is still fine in a single PR. If not, then feel free to close and I create multiple PRs for that.