### PR TITLE
Fix comments in strings.po file

### DIFF
--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -96,7 +96,7 @@ msgctxt "#31017"
 msgid "Unavailable"
 msgstr ""
 
-#empty strings from id 31018 to 31022
+# empty strings from id 31018 to 31022
 
 msgctxt "#31023"
 msgid "Playing"
@@ -118,7 +118,7 @@ msgctxt "#31027"
 msgid "Location"
 msgstr ""
 
-#View Type labels
+# View Type labels
 
 msgctxt "#31028"
 msgid "Poster wrap"
@@ -128,7 +128,7 @@ msgctxt "#31029"
 msgid "Fanart"
 msgstr ""
 
-#empty string with id 31030
+# empty string with id 31030
 
 msgctxt "#31031"
 msgid "Pic thumbs"
@@ -142,19 +142,19 @@ msgctxt "#31033"
 msgid "Info"
 msgstr ""
 
-#empty strings from id 31034 to 31038
+# empty strings from id 31034 to 31038
 
 msgctxt "#31039"
 msgid "Actions"
 msgstr ""
 
-#Extra labels
+# Extra labels
 
 msgctxt "#31040"
 msgid "Now playing"
 msgstr ""
 
-#empty string with id 31041
+# empty string with id 31041
 
 msgctxt "#31042"
 msgid "PLAYING"
@@ -176,7 +176,7 @@ msgctxt "#31046"
 msgid "SEEKING"
 msgstr ""
 
-#empty string with id 31047
+# empty string with id 31047
 
 msgctxt "#31048"
 msgid "Visualisation presets"
@@ -194,8 +194,8 @@ msgctxt "#31051"
 msgid "Sort: Descending"
 msgstr ""
 
-#empty strings from id 31052 to 31054
-#Playlist Editor labels
+# empty strings from id 31052 to 31054
+# Playlist Editor labels
 
 msgctxt "#31055"
 msgid "Open playlist"
@@ -217,14 +217,14 @@ msgctxt "#31059"
 msgid "Current playlist"
 msgstr ""
 
-#empty string with id 31060
+# empty string with id 31060
 
 msgctxt "#31061"
 msgid "Current selected"
 msgstr ""
 
-#empty strings from id 31062 to 31100
-#Skin Settings labels
+# empty strings from id 31062 to 31100
+# Skin Settings labels
 
 msgctxt "#31101"
 msgid "Home screen options"
@@ -242,7 +242,7 @@ msgctxt "#31104"
 msgid "Play trailers in a window [COLOR=grey3](Video information dialogue only)[/COLOR]"
 msgstr ""
 
-#empty string with id 31105
+# empty string with id 31105
 
 msgctxt "#31106"
 msgid "Miscellaneous options"
@@ -306,7 +306,7 @@ msgctxt "#31120"
 msgid "Home page \"Games\" submenu"
 msgstr ""
 
-#empty string with id 31121
+# empty string with id 31121
 
 #. Boolean settings value
 #: system/settings/settings.xml
@@ -314,7 +314,7 @@ msgctxt "#31122"
 msgid "Hide EPG if RDS is present on channel window"
 msgstr ""
 
-#empty string with id 31123
+# empty string with id 31123
 
 msgctxt "#31124"
 msgid "Show background \"Now playing\" video"
@@ -324,7 +324,7 @@ msgctxt "#31125"
 msgid "Show background \"Now playing\" visualisation"
 msgstr ""
 
-#empty strings from id 31126 to 31127
+# empty strings from id 31126 to 31127
 
 msgctxt "#31128"
 msgid "Lyrics"
@@ -334,13 +334,13 @@ msgctxt "#31129"
 msgid "Hide fanart in full screen visualisation"
 msgstr ""
 
-#empty strings from id 31130 to 31131
+# empty strings from id 31130 to 31131
 
 msgctxt "#31132"
 msgid "Lyrics add-on"
 msgstr ""
 
-#empty string with id 31133
+# empty string with id 31133
 
 #. In main language strings its used as submenu
 msgctxt "#31134"
@@ -355,13 +355,13 @@ msgctxt "#31136"
 msgid "Home page \"Pictures\" submenu"
 msgstr ""
 
-#empty strings from id 31137 to 31139
+# empty strings from id 31137 to 31139
 
 msgctxt "#31140"
 msgid "Music OSD"
 msgstr ""
 
-#empty string with id 31141
+# empty string with id 31141
 
 msgctxt "#31142"
 msgid "Settings level"
@@ -379,20 +379,20 @@ msgctxt "#31145"
 msgid "playlist path"
 msgstr ""
 
-#empty strings from id 31146 to 31199
-#Script labels
+# empty strings from id 31146 to 31199
+# Script labels
 
 msgctxt "#31200"
 msgid "Shortcuts"
 msgstr ""
 
-#empty strings from id 31201 to 31202
+# empty strings from id 31201 to 31202
 
 msgctxt "#31203"
 msgid "Choose your song"
 msgstr ""
 
-#empty string with id 31204
+# empty string with id 31204
 
 msgctxt "#31205"
 msgid "Lyrics source"
@@ -414,8 +414,8 @@ msgctxt "#31209"
 msgid "Hide Master profile main menu buttons"
 msgstr ""
 
-#empty strings from id 31210 to 31299
-#Extra labels
+# empty strings from id 31210 to 31299
+# Extra labels
 
 msgctxt "#31300"
 msgid "Current temperature"
@@ -425,13 +425,13 @@ msgctxt "#31301"
 msgid "Last updated"
 msgstr ""
 
-#empty string with id 31302
+# empty string with id 31302
 
 msgctxt "#31303"
 msgid "Data provider"
 msgstr ""
 
-#empty strings from id 31304 to 31307
+# empty strings from id 31304 to 31307
 
 msgctxt "#31308"
 msgid "Movie details"
@@ -445,7 +445,7 @@ msgctxt "#31310"
 msgid "Track number"
 msgstr ""
 
-#empty strings from id 31311 to 31318
+# empty strings from id 31311 to 31318
 
 msgctxt "#31319"
 msgid "Selected profile"
@@ -455,13 +455,13 @@ msgctxt "#31320"
 msgid "Last logged in"
 msgstr ""
 
-#empty string with id 31321
+# empty string with id 31321
 
 msgctxt "#31322"
 msgid "Aired"
 msgstr ""
 
-#empty strings from id 31323 to 31324
+# empty strings from id 31323 to 31324
 
 msgctxt "#31325"
 msgid "Playlist options"
@@ -491,8 +491,8 @@ msgctxt "#31331"
 msgid "Album details"
 msgstr ""
 
-#empty strings from id 31332 to 31350
-#Video and Music OSD Labels
+# empty strings from id 31332 to 31350
+# Video and Music OSD Labels
 
 msgctxt "#31351"
 msgid "Pause"
@@ -518,7 +518,7 @@ msgctxt "#31356"
 msgid "Download subtitles"
 msgstr ""
 
-#empty strings from id 31357 to 31359
+# empty strings from id 31357 to 31359
 
 # Stereoscopic labels
 msgctxt "#31360"
@@ -533,7 +533,7 @@ msgctxt "#31362"
 msgid "Enabled"
 msgstr ""
 
-#empty strings from id 31363 to 31389
+# empty strings from id 31363 to 31389
 
 msgctxt "#31390"
 msgid "Skin default"
@@ -547,7 +547,7 @@ msgctxt "#31392"
 msgid "Arial based"
 msgstr ""
 
-#empty strings from id 31393 to 31410
+# empty strings from id 31393 to 31410
 
 msgctxt "#31411"
 msgid "First run help..."
@@ -561,7 +561,7 @@ msgctxt "#31413"
 msgid "Local subtitle available"
 msgstr ""
 
-#empty strings from id 31414 to 31419
+# empty strings from id 31414 to 31419
 
 msgctxt "#31420"
 msgid "Login"
@@ -579,7 +579,7 @@ msgctxt "#31423"
 msgid "Select the profile that will be used at startup when the login screen is disabled."
 msgstr ""
 
-#empty strings from id 31424 to 31429
+# empty strings from id 31424 to 31429
 
 msgctxt "#31430"
 msgid "[B]PLAYER SETTINGS[/B][CR][CR]Configure actions that can be used during playback · Configure how media content is played"
@@ -609,7 +609,7 @@ msgctxt "#31436"
 msgid "[B]INTERFACE SETTINGS[/B][CR][CR]Configure skin · Configure region · Configure control · Configure screensaver · Configure master lock"
 msgstr ""
 
-#empty strings from id 31437 to 31500
+# empty strings from id 31437 to 31500
 
 msgctxt "#31501"
 msgid "Scheduled time"
@@ -635,7 +635,7 @@ msgctxt "#31506"
 msgid "Available[CR]Groups"
 msgstr ""
 
-#empty strings from id 31507 to 31508
+# empty strings from id 31507 to 31508
 
 msgctxt "#31509"
 msgid "Channel group"
@@ -649,8 +649,8 @@ msgctxt "#31511"
 msgid "Channel options"
 msgstr ""
 
-#empty strings from id 31512 to 31900
-#Weather plugin
+# empty strings from id 31512 to 31900
+# Weather plugin
 
 msgctxt "#31901"
 msgid "36-hour forecast"
@@ -672,7 +672,7 @@ msgctxt "#31905"
 msgid "Forecast"
 msgstr ""
 
-#empty strings from id 31906 to 31908
+# empty strings from id 31906 to 31908
 
 msgctxt "#31909"
 msgid "Fetching forecast info..."
@@ -682,7 +682,7 @@ msgctxt "#31910"
 msgid "Maps"
 msgstr ""
 
-#empty strings from id 31911 to 31949
+# empty strings from id 31911 to 31949
 
 msgctxt "#31950"
 msgid "WEATHER"


### PR DESCRIPTION
Let's make our addon checker happy ;)

Added spaces after every `#` where it hasn't been a `.` or `:` or `|` 