### PR TITLE
Language files and changlog backports (#68)

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.confluence" version="4.6.8" name="Confluence" provider-name="Jezz_X, Team Kodi">
+<addon id="skin.confluence" version="4.6.9" name="Confluence" provider-name="Jezz_X, Team Kodi">
 	<requires>
 		<import addon="xbmc.gui" version="5.14.0"/>
 	</requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,114 @@
+[B]4.6.9[/B]
+
+- Media flagging updates
+- Language updates
+
+[B]4.6.8[/B]
+
+- Add HasArchive indicator to channels and programs
+- Add CoreELEC compatibility
+
+[B]4.6.7[/B]
+
+- Language updates
+
+[B]4.6.6[/B]
+
+- Language updates
+- Fix comments in strings.po
+- Fix addon.xml
+
+[B]4.6.5[/B]
+
+- Language updates
+- Fix endtime visibility for video info screen
+- Add video duration into view
+
+[B]4.6.4[/B]
+
+- Add "End time" for video playback
+- Add add-ons submenu
+- Music artist info updated
+- Power/Favourites buttons updated
+
+[B]4.6.3[/B]
+
+- Fix now playing issue
+
+[B]4.6.2[/B]
+
+- Tags fixed
+
+[B]4.6.1[/B]
+
+- Language updates
+
+[B]4.6.0[/B]
+
+- Added "Kids profile" option
+
+[B]4.5.15[/B]
+
+- Fix game stretch mode
+
+[B]4.5.14[/B]
+
+- Unused include removed (NowPlaying)
+
+[B]4.5.13[/B]
+
+- Fixed missing labels
+- Removed audio dsp references
+
+[B]4.5.12[/B]
+
+- Language updates
+
+[B]4.5.11[/B]
+
+- Add "Rip CD" button to home sub menu
+
+[B]4.5.10[/B]
+
+- Language updates
+
+[B]4.5.9[/B]
+
+- Fix menu visibility when offsetting subtitles
+
+[B[4.5.8[/B]
+
+- Language updates
+
+[B]4.5.7[/B]
+
+- Language updates
+
+[B]4.5.6[/B]
+
+- Refactor media info/now playing views
+- Support for hide plot/thumb (OverlaySpoiler.png)
+
+[B]4.5.5[/B]
+
+- GUI version bump to 5.14.0
+- Fonts updates
+- Language updates
+
+[B]4.5.4[/B]
+
+- Fix missing video and audio codec flags
+
+[B]4.5.3[/B]
+
+- Fix album start rating
+- Fix missing localisation
+
+[B]4.5.2[/B]
+
+- Added 8K support
+- Add setting for profile identification
+
 [B]4.5.1[/B]
 
 - Audio DSP support removed 

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -16,14 +16,6 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-# [Consistency] Make terms, settings names, brands and other minutiae, consistent throughout file.
-# [Capitalization] Avoid capitalizing every second word. See http://grammarist.com/capitalization/
-# For example, prefer wording as "This new string" instead of "This New String".
-# [Referencing] If a suitable string already exists, reuse it, making a note of where it's used!
-# [Description / location] For example, "#. Description of some setting" used on "#: xbmc/addons/guidialogaddoninfo.cpp"
-# When writing a description or setting, refer to a setting name in quotes. See existing entries for guidance.
-# For example, "Press \"OK\" for \"All seasons\"" instead of "Press OK for All seasons" after first word.
-
 msgctxt "#31000"
 msgid "Change your"
 msgstr ""
@@ -96,7 +88,7 @@ msgctxt "#31017"
 msgid "Unavailable"
 msgstr ""
 
-# empty strings from id 31018 to 31022
+#empty strings from id 31018 to 31022
 
 msgctxt "#31023"
 msgid "Playing"
@@ -118,8 +110,6 @@ msgctxt "#31027"
 msgid "Location"
 msgstr ""
 
-# View Type labels
-
 msgctxt "#31028"
 msgid "Poster wrap"
 msgstr ""
@@ -128,7 +118,7 @@ msgctxt "#31029"
 msgid "Fanart"
 msgstr ""
 
-# empty string with id 31030
+#empty string with id 31030
 
 msgctxt "#31031"
 msgid "Pic thumbs"
@@ -142,19 +132,17 @@ msgctxt "#31033"
 msgid "Info"
 msgstr ""
 
-# empty strings from id 31034 to 31038
+#empty strings from id 31034 to 31038
 
 msgctxt "#31039"
 msgid "Actions"
 msgstr ""
 
-# Extra labels
-
 msgctxt "#31040"
 msgid "Now playing"
 msgstr ""
 
-# empty string with id 31041
+#empty string with id 31041
 
 msgctxt "#31042"
 msgid "PLAYING"
@@ -176,7 +164,7 @@ msgctxt "#31046"
 msgid "SEEKING"
 msgstr ""
 
-# empty string with id 31047
+#empty string with id 31047
 
 msgctxt "#31048"
 msgid "Visualisation presets"
@@ -194,8 +182,7 @@ msgctxt "#31051"
 msgid "Sort: Descending"
 msgstr ""
 
-# empty strings from id 31052 to 31054
-# Playlist Editor labels
+#empty strings from id 31052 to 31054
 
 msgctxt "#31055"
 msgid "Open playlist"
@@ -217,14 +204,13 @@ msgctxt "#31059"
 msgid "Current playlist"
 msgstr ""
 
-# empty string with id 31060
+#empty string with id 31060
 
 msgctxt "#31061"
 msgid "Current selected"
 msgstr ""
 
-# empty strings from id 31062 to 31100
-# Skin Settings labels
+#empty strings from id 31062 to 31100
 
 msgctxt "#31101"
 msgid "Home screen options"
@@ -242,7 +228,7 @@ msgctxt "#31104"
 msgid "Play trailers in a window [COLOR=grey3](Video information dialogue only)[/COLOR]"
 msgstr ""
 
-# empty string with id 31105
+#empty string with id 31105
 
 msgctxt "#31106"
 msgid "Miscellaneous options"
@@ -306,7 +292,7 @@ msgctxt "#31120"
 msgid "Home page \"Games\" submenu"
 msgstr ""
 
-# empty string with id 31121
+#empty string with id 31121
 
 #. Boolean settings value
 #: system/settings/settings.xml
@@ -314,7 +300,7 @@ msgctxt "#31122"
 msgid "Hide EPG if RDS is present on channel window"
 msgstr ""
 
-# empty string with id 31123
+#empty string with id 31123
 
 msgctxt "#31124"
 msgid "Show background \"Now playing\" video"
@@ -324,7 +310,7 @@ msgctxt "#31125"
 msgid "Show background \"Now playing\" visualisation"
 msgstr ""
 
-# empty strings from id 31126 to 31127
+#empty strings from id 31126 to 31127
 
 msgctxt "#31128"
 msgid "Lyrics"
@@ -334,13 +320,13 @@ msgctxt "#31129"
 msgid "Hide fanart in full screen visualisation"
 msgstr ""
 
-# empty strings from id 31130 to 31131
+#empty strings from id 31130 to 31131
 
 msgctxt "#31132"
 msgid "Lyrics add-on"
 msgstr ""
 
-# empty string with id 31133
+#empty string with id 31133
 
 #. In main language strings its used as submenu
 msgctxt "#31134"
@@ -355,13 +341,13 @@ msgctxt "#31136"
 msgid "Home page \"Pictures\" submenu"
 msgstr ""
 
-# empty strings from id 31137 to 31139
+#empty strings from id 31137 to 31139
 
 msgctxt "#31140"
 msgid "Music OSD"
 msgstr ""
 
-# empty string with id 31141
+#empty string with id 31141
 
 msgctxt "#31142"
 msgid "Settings level"
@@ -379,20 +365,19 @@ msgctxt "#31145"
 msgid "playlist path"
 msgstr ""
 
-# empty strings from id 31146 to 31199
-# Script labels
+#empty strings from id 31146 to 31199
 
 msgctxt "#31200"
 msgid "Shortcuts"
 msgstr ""
 
-# empty strings from id 31201 to 31202
+#empty strings from id 31201 to 31202
 
 msgctxt "#31203"
 msgid "Choose your song"
 msgstr ""
 
-# empty string with id 31204
+#empty string with id 31204
 
 msgctxt "#31205"
 msgid "Lyrics source"
@@ -414,8 +399,7 @@ msgctxt "#31209"
 msgid "Hide Master profile main menu buttons"
 msgstr ""
 
-# empty strings from id 31210 to 31299
-# Extra labels
+#empty strings from id 31210 to 31299
 
 msgctxt "#31300"
 msgid "Current temperature"
@@ -425,13 +409,13 @@ msgctxt "#31301"
 msgid "Last updated"
 msgstr ""
 
-# empty string with id 31302
+#empty string with id 31302
 
 msgctxt "#31303"
 msgid "Data provider"
 msgstr ""
 
-# empty strings from id 31304 to 31307
+#empty strings from id 31304 to 31307
 
 msgctxt "#31308"
 msgid "Movie details"
@@ -445,7 +429,7 @@ msgctxt "#31310"
 msgid "Track number"
 msgstr ""
 
-# empty strings from id 31311 to 31318
+#empty strings from id 31311 to 31318
 
 msgctxt "#31319"
 msgid "Selected profile"
@@ -455,13 +439,13 @@ msgctxt "#31320"
 msgid "Last logged in"
 msgstr ""
 
-# empty string with id 31321
+#empty string with id 31321
 
 msgctxt "#31322"
 msgid "Aired"
 msgstr ""
 
-# empty strings from id 31323 to 31324
+#empty strings from id 31323 to 31324
 
 msgctxt "#31325"
 msgid "Playlist options"
@@ -491,8 +475,7 @@ msgctxt "#31331"
 msgid "Album details"
 msgstr ""
 
-# empty strings from id 31332 to 31350
-# Video and Music OSD Labels
+#empty strings from id 31332 to 31350
 
 msgctxt "#31351"
 msgid "Pause"
@@ -518,7 +501,7 @@ msgctxt "#31356"
 msgid "Download subtitles"
 msgstr ""
 
-# empty strings from id 31357 to 31359
+#empty strings from id 31357 to 31359
 
 # Stereoscopic labels
 msgctxt "#31360"
@@ -533,7 +516,7 @@ msgctxt "#31362"
 msgid "Enabled"
 msgstr ""
 
-# empty strings from id 31363 to 31389
+#empty strings from id 31363 to 31389
 
 msgctxt "#31390"
 msgid "Skin default"
@@ -547,7 +530,7 @@ msgctxt "#31392"
 msgid "Arial based"
 msgstr ""
 
-# empty strings from id 31393 to 31410
+#empty strings from id 31393 to 31410
 
 msgctxt "#31411"
 msgid "First run help..."
@@ -561,7 +544,7 @@ msgctxt "#31413"
 msgid "Local subtitle available"
 msgstr ""
 
-# empty strings from id 31414 to 31419
+#empty strings from id 31414 to 31419
 
 msgctxt "#31420"
 msgid "Login"
@@ -579,7 +562,7 @@ msgctxt "#31423"
 msgid "Select the profile that will be used at startup when the login screen is disabled."
 msgstr ""
 
-# empty strings from id 31424 to 31429
+#empty strings from id 31424 to 31429
 
 msgctxt "#31430"
 msgid "[B]PLAYER SETTINGS[/B][CR][CR]Configure actions that can be used during playback · Configure how media content is played"
@@ -609,7 +592,7 @@ msgctxt "#31436"
 msgid "[B]INTERFACE SETTINGS[/B][CR][CR]Configure skin · Configure region · Configure control · Configure screensaver · Configure master lock"
 msgstr ""
 
-# empty strings from id 31437 to 31500
+#empty strings from id 31437 to 31500
 
 msgctxt "#31501"
 msgid "Scheduled time"
@@ -635,7 +618,7 @@ msgctxt "#31506"
 msgid "Available[CR]Groups"
 msgstr ""
 
-# empty strings from id 31507 to 31508
+#empty strings from id 31507 to 31508
 
 msgctxt "#31509"
 msgid "Channel group"
@@ -649,8 +632,7 @@ msgctxt "#31511"
 msgid "Channel options"
 msgstr ""
 
-# empty strings from id 31512 to 31900
-# Weather plugin
+#empty strings from id 31512 to 31900
 
 msgctxt "#31901"
 msgid "36-hour forecast"
@@ -672,7 +654,7 @@ msgctxt "#31905"
 msgid "Forecast"
 msgstr ""
 
-# empty strings from id 31906 to 31908
+#empty strings from id 31906 to 31908
 
 msgctxt "#31909"
 msgid "Fetching forecast info..."
@@ -682,7 +664,7 @@ msgctxt "#31910"
 msgid "Maps"
 msgstr ""
 
-# empty strings from id 31911 to 31949
+#empty strings from id 31911 to 31949
 
 msgctxt "#31950"
 msgid "WEATHER"

--- a/language/resource.language.es_es/strings.po
+++ b/language/resource.language.es_es/strings.po
@@ -474,7 +474,7 @@ msgstr "Ayuda para la primera vez..."
 
 msgctxt "#31412"
 msgid "This tab signifies that there is a menu off to the side of this window that contains extra options for this section. To access the menu, navigate to the left with your remote control or keyboard or place your mouse pointer over the tab. [CR][CR]Click \"OK\" to close this dialogue. It will not appear again."
-msgstr "Esta pestaña significa que hay un menú a un lado de esta ventana que contiene opciones adicionales para esta sección. Para acceder al menú, desplácese a la izquierda con el mando a distancia o el teclado, o sitúe el puntero del ratón sobre la pestaña. [CR][CR]Haga clic en \"Aceptar\" para cerrar este cuadro de diálogo. No volverá a aparecer."
+msgstr "Esta pestaña significa que hay un menú a un lado de esta ventana que contiene opciones adicionales para esta sección. Para acceder al menú, desplácese a la izquierda con el mando a distancia o el teclado, o sitúe el puntero del ratón sobre la pestaña. [CR][CR]Haga clic en \"OK\" para cerrar este cuadro de diálogo. No volverá a aparecer."
 
 msgctxt "#31413"
 msgid "Local subtitle available"
@@ -502,7 +502,7 @@ msgstr "[B]AJUSTES DEL REPRODUCTOR[/B][CR][CR]Configura acciones que se pueden u
 
 msgctxt "#31431"
 msgid "[B]LIBRARY SETTINGS[/B][CR][CR]Configure how the library/file views display media content ·  Configure how library lists/views are navigated · Configure the media database options"
-msgstr "[B]AJUSTES DE LA COLECCIÓN[/B][CR][CR]Configura cómo se muestran los contenidos en las vistas de Archivos o Colecciones · Configura cómo se navega por las vistas de Archivos o Colecciones · Configura las opciones de las bases de datos de medios"
+msgstr "[B]AJUSTES DE LA COLECCIÓN[/B][CR][CR]Configura cómo se muestran los contenidos en las vistas de Archivos o Colecciones · Configura cómo se navega por las vistas de Archivos o Colecciones · Configura las opciones de las bases de datos de contenido"
 
 msgctxt "#31432"
 msgid "[B]PVR SETTINGS[/B][CR][CR]Configure how the channels & guide are managed  · Configure how Live TV and recordings are managed"
@@ -510,7 +510,7 @@ msgstr "[B]AJUSTES DE PVR[/B][CR][CR]Configura la gestión de los canales y la g
 
 msgctxt "#31433"
 msgid "[B]ADD-ONS SETTINGS[/B][CR][CR]Configure your installed add-ons · Browse for and install add-ons from kodi.tv"
-msgstr "[B]AJUSTES DE ADD-ONS[/B][CR][CR]Configura sus addons instalados · Navega e instala add-ons procedentes de kodi.tv"
+msgstr "[B]AJUSTES DE ADD-ONS[/B][CR][CR]Configura los add-on instalados · Navega e instala add-ons procedentes de kodi.tv"
 
 msgctxt "#31434"
 msgid "[B]SERVICES SETTINGS[/B][CR][CR]Configure & manage media sharing services · Configure web server · Configure & manage the weather service"

--- a/language/resource.language.pl_pl/strings.po
+++ b/language/resource.language.pl_pl/strings.po
@@ -240,9 +240,17 @@ msgctxt "#31112"
 msgid "Options"
 msgstr "Opcje"
 
+msgctxt "#31113"
+msgid "Background path Master:"
+msgstr "Ścieżki w tle głównego profilu:"
+
 msgctxt "#31114"
 msgid "System"
 msgstr "Systemowe"
+
+msgctxt "#31115"
+msgid "Main button playlists"
+msgstr "Listy odtwarzania głównego przycisku"
 
 msgctxt "#31116"
 msgid "Show recently added albums"
@@ -312,6 +320,14 @@ msgctxt "#31143"
 msgid "Use"
 msgstr "Użyj"
 
+msgctxt "#31144"
+msgid "playlist"
+msgstr "lista odtwarzania"
+
+msgctxt "#31145"
+msgid "playlist path"
+msgstr "ścieżka listy odtwarzania"
+
 msgctxt "#31200"
 msgid "Shortcuts"
 msgstr "Skróty"
@@ -335,6 +351,10 @@ msgstr "Znajdź więcej pozycji"
 msgctxt "#31208"
 msgid "Upcoming episodes"
 msgstr "Odcinki wkrótce na antenie"
+
+msgctxt "#31209"
+msgid "Hide Master profile main menu buttons"
+msgstr "Ukryj przyciski menu profilu głównego"
 
 msgctxt "#31300"
 msgid "Current temperature"

--- a/language/resource.language.ro_ro/strings.po
+++ b/language/resource.language.ro_ro/strings.po
@@ -240,9 +240,17 @@ msgctxt "#31112"
 msgid "Options"
 msgstr "Opțiuni"
 
+msgctxt "#31113"
+msgid "Background path Master:"
+msgstr "Adresa fundal principal:"
+
 msgctxt "#31114"
 msgid "System"
 msgstr "Sistem"
+
+msgctxt "#31115"
+msgid "Main button playlists"
+msgstr "Listele de redare ale butoanelor principale"
 
 msgctxt "#31116"
 msgid "Show recently added albums"
@@ -312,6 +320,14 @@ msgctxt "#31143"
 msgid "Use"
 msgstr "Utilizează"
 
+msgctxt "#31144"
+msgid "playlist"
+msgstr "lista de redare"
+
+msgctxt "#31145"
+msgid "playlist path"
+msgstr "adresa/cale catre lista de redare"
+
 msgctxt "#31200"
 msgid "Shortcuts"
 msgstr "Scurtături"
@@ -335,6 +351,10 @@ msgstr "Găsește mai multe elemente"
 msgctxt "#31208"
 msgid "Upcoming episodes"
 msgstr "Episoade viitoare"
+
+msgctxt "#31209"
+msgid "Hide Master profile main menu buttons"
+msgstr "Ascunde butoanele principale ale meniului profilului Master"
 
 msgctxt "#31300"
 msgid "Current temperature"


### PR DESCRIPTION
* [lang][skin.confluence] automatic syntax corrections for the en_GB language file

* [lang] updated language files from Transifex

* changelog updates