### PR TITLE
Home screen widgets show only unwatched items

### DIFF
--- a/720p/IncludesHomeRecentlyAdded.xml
+++ b/720p/IncludesHomeRecentlyAdded.xml
@@ -137,7 +137,7 @@
 							<visible>Control.HasFocus(8000)</visible>
 						</control>
 					</focusedlayout>
-					<content sortorder="descending" sortby="dateadded" limit="10">videodb://movies/titles</content>
+					<content target="video"  sortorder="descending" sortby="dateadded" limit="15">videodb://movies/titles/?xsp=%7B%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22playcount%22%2C%22operator%22%3A%22is%22%2C%22value%22%3A%220%22%7D%5D%7D%2C%22type%22%3A%22movies%22%7D</content>
 				</control>
 				<control type="button">
 					<description>left Arrow</description>
@@ -317,7 +317,7 @@
 							<visible>Control.HasFocus(8001)</visible>
 						</control>
 					</focusedlayout>
-					<content sortorder="descending" sortby="dateadded" limit="10">videodb://tvshows/titles/-1/-1/</content>
+					<content target="video" sortorder="descending" sortby="dateadded" limit="15">videodb://tvshows/titles/-1/-1/?xsp=%7B%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22playcount%22%2C%22operator%22%3A%22is%22%2C%22value%22%3A%220%22%7D%5D%7D%2C%22type%22%3A%22episodes%22%7D</content>
 				</control>
 				<control type="button">
 					<description>left Arrow</description>
@@ -498,7 +498,7 @@
 							<visible>Control.HasFocus(8002)</visible>
 						</control>
 					</focusedlayout>
-					<content sortby="dateadded" sortorder="descending" limit="10">musicdb://recentlyaddedalbums</content>
+					<content target="music" sortby="dateadded" sortorder="descending" limit="15">musicdb://recentlyaddedalbums</content>
 				</control>
 				<control type="button">
 					<description>left Arrow</description>

--- a/addon.xml
+++ b/addon.xml
@@ -143,6 +143,6 @@
 			<screenshot>resources/screenshot-08.jpg</screenshot>
 			<screenshot>resources/screenshot-09.jpg</screenshot>
 		</assets>
-		<news>- Switch to dynamic content for home screen widgets.</news>
+		<news>- Switch to dynamic content for home screen widgets.[CR]- Home screen widgets show only unwatched items.</news>
 	</extension>
 </addon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 [B]4.7.6[/B]
 
 - Switch to dynamic content for home screen widgets
+- Home screen widgets show only unwatched items
 
 [B]4.7.5[/B]
 


### PR DESCRIPTION
This PR adds:

- Home screen widgets show only unwatched items
- Increase widgets to contain 15 items (before 10)