### PR TITLE
Add "Reboot from eMMC/NAND" to the power menu

### DIFF
--- a/720p/DialogButtonMenu.xml
+++ b/720p/DialogButtonMenu.xml
@@ -65,7 +65,7 @@
 					<texturenofocus>DialogCloseButton.png</texturenofocus>
 					<onleft>2</onleft>
 					<onright>13</onright>
-					<onup>13</onup>
+					<onup>14</onup>
 					<ondown>2</ondown>
 					<visible>system.getbool(input.enablemouse)</visible>
 				</control>
@@ -278,7 +278,24 @@
 				<label>13018</label>
 				<visible>System.HasShutdown + System.IsInhibit</visible>
 			</control>
-			<control type="image" id="14">
+			<control type="button" id="14">
+				<description>Reboot from eMMC/NAND</description>
+				<width>340</width>
+				<height>40</height>
+				<textcolor>grey2</textcolor>
+				<focusedcolor>white</focusedcolor>
+				<align>center</align>
+				<textwidth>290</textwidth>
+				<texturefocus border="25,5,25,5">ShutdownButtonFocus.png</texturefocus>
+				<texturenofocus border="25,5,25,5">ShutdownButtonNoFocus.png</texturenofocus>
+				<onclick>System.ExecWait("/usr/sbin/rebootfromnand")</onclick>
+				<onclick>Reset()</onclick>
+				<pulseonselect>no</pulseonselect>
+				<font>font13</font>
+				<label>Reboot from eMMC/NAND</label>
+				<visible>System.PathExist("/dev/system")</visible>
+			</control>
+			<control type="image" id="15">
 				<description>background bottom image</description>
 				<left>0</left>
 				<width>340</width>


### PR DESCRIPTION
Android TV box boots into CoreElec/Kodi by default and without this menu
entry you have to remove the sd-card or use a shell command to reboot to
the Android system.

Command specification is from the estuary skin.