### PR TITLE
[Matrix] Fix subtitles icon

### DIFF
--- a/720p/VideoFullScreen.xml
+++ b/720p/VideoFullScreen.xml
@@ -308,7 +308,7 @@
 					<control type="group" id="1">
 						<width>85</width>
 						<height>35</height>
-						<visible>![String.IsEmpty(VideoPlayer.SubtitlesLanguage) | Player.ChannelPreviewActive]</visible>
+						<visible>![String.IsEmpty(VideoPlayer.SubtitlesLanguage) | Player.ChannelPreviewActive] + VideoPlayer.SubtitlesEnabled</visible>
 						<control type="image" id="1">
 							<left>5</left>
 							<top>0</top>


### PR DESCRIPTION
This fixes the issue where the subtitles icon is visible even is subtitles are disabled.

Matrix branch

Fixes:
https://github.com/xbmc/skin.confluence/issues/104
https://github.com/xbmc/skin.confluence/issues/78