### PR TITLE
Ability to show title / originaltitle

### DIFF
--- a/720p/DialogVideoInfo.xml
+++ b/720p/DialogVideoInfo.xml
@@ -379,6 +379,11 @@
 						</focusedlayout>
 						<content>
 							<item>
+								<label>$LOCALIZE[20376]:</label>
+								<label2>$INFO[ListItem.OriginalTitle]</label2>
+								<visible>!String.IsEmpty(ListItem.OriginalTitle) + !String.IsEqual(ListItem.OriginalTitle,Listitem.Title)</visible>
+							</item>
+							<item>
 								<label>$LOCALIZE[20360]:</label>
 								<label2>$INFO[listitem.episode] [COLOR=grey] ($INFO[ListItem.Property(WatchedEpisodes),, $LOCALIZE[16102]] - $INFO[ListItem.Property(UnWatchedEpisodes), , $LOCALIZE[16101]])[/COLOR]</label2>
 								<visible>!String.IsEmpty(ListItem.Episode)</visible>

--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -578,6 +578,18 @@
 		<value condition="Skin.HasSetting(show_profileavatar)">$LOCALIZE[31964]</value>
 		<value>$LOCALIZE[16018]</value>
 	</variable>
+	<variable name="ShowOriginalName">
+		<value condition="Skin.HasSetting(ortitle_1st)">$LOCALIZE[31173]</value>
+		<value condition="Skin.HasSetting(ortitle_2nd)">$LOCALIZE[31174]</value>
+		<value condition="Skin.HasSetting(ortitle_only)">$LOCALIZE[31175]</value>
+		<value>$LOCALIZE[31172]</value>
+	</variable>
+	<variable name="ShowCustomLabel">
+		<value condition="Skin.HasSetting(ortitle_1st) + !String.IsEmpty(ListItem.OriginalTitle) + !String.IsEqual(ListItem.Label,ListItem.OriginalTitle)">$INFO[ListItem.OriginalTitle] ($INFO[ListItem.Label])</value>
+		<value condition="Skin.HasSetting(ortitle_2nd) + !String.IsEmpty(ListItem.OriginalTitle) + !String.IsEqual(ListItem.Label,ListItem.OriginalTitle)">$INFO[ListItem.Label] ($INFO[ListItem.OriginalTitle])</value>
+		<value condition="Skin.HasSetting(ortitle_only) + !String.IsEmpty(ListItem.OriginalTitle) + !String.IsEqual(ListItem.Label,ListItem.OriginalTitle)">$INFO[ListItem.OriginalTitle]</value>
+		<value>$INFO[ListItem.Label]</value>
+	</variable>
 	<!-- INCLUDES -->
 	<include name="MusicInfoPanel">
 		<control type="panel" id="50">

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -281,6 +281,18 @@
 						<onclick>Skin.SelectBool(31962, 31963|show_profilename, 31964|show_profileavatar, 16018|show_none)</onclick>
 						<label2>$VAR[ProfileIdentificationLabel2Var]</label2>
 					</control>
+					<control type="button" id="118">
+						<width>750</width>
+						<height>40</height>
+						<font>font13</font>
+						<label>31171</label>
+						<textcolor>grey2</textcolor>
+						<focusedcolor>white</focusedcolor>
+						<texturefocus>MenuItemFO.png</texturefocus>
+						<texturenofocus>MenuItemNF.png</texturenofocus>
+						<onclick>Skin.SelectBool(31171, 31172|ortitle_nothing, 31175|ortitle_only, 31173|ortitle_1st, 31174|ortitle_2nd)</onclick>
+						<label2>$VAR[ShowOriginalName]</label2>
+					</control>
 				</control>
 				<control type="scrollbar" id="60">
 					<left>1060</left>

--- a/720p/ViewsFileMode.xml
+++ b/720p/ViewsFileMode.xml
@@ -34,7 +34,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="label">
 						<left>280</left>
@@ -127,7 +127,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="label">
 						<left>280</left>
@@ -535,7 +535,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="label">
 						<left>60</left>
@@ -636,7 +636,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="label">
 						<left>60</left>

--- a/720p/ViewsVideoLibrary.xml
+++ b/720p/ViewsVideoLibrary.xml
@@ -131,7 +131,7 @@
 				<scroll>true</scroll>
 				<align>center</align>
 				<aligny>center</aligny>
-				<label>$INFO[ListItem.Label]</label>
+				<label>$VAR[ShowCustomLabel]</label>
 			</control>
 			<control type="label">
 				<left>0</left>
@@ -199,7 +199,7 @@
 				<scroll>true</scroll>
 				<align>center</align>
 				<aligny>center</aligny>
-				<label>$INFO[ListItem.Label]</label>
+				<label>$VAR[ShowCustomLabel]</label>
 			</control>
 			<control type="label">
 				<left>0</left>
@@ -250,7 +250,7 @@
 				<scroll>true</scroll>
 				<align>center</align>
 				<aligny>center</aligny>
-				<label>$INFO[ListItem.Label]</label>
+				<label>$VAR[ShowCustomLabel]</label>
 			</control>
 			<control type="label">
 				<left>0</left>
@@ -314,7 +314,7 @@
 				<scroll>true</scroll>
 				<align>center</align>
 				<aligny>center</aligny>
-				<label>$INFO[ListItem.Label]</label>
+				<label>$VAR[ShowCustomLabel]</label>
 				<animation effect="slide" start="0,0" end="0,25" time="150" condition="!Control.HasFocus(508)">conditional</animation>
 			</control>
 		</control>
@@ -462,7 +462,7 @@
 				<scroll>true</scroll>
 				<align>center</align>
 				<aligny>center</aligny>
-				<label>$INFO[ListItem.Label]</label>
+				<label>$VAR[ShowCustomLabel]</label>
 			</control>
 			<control type="group">
 				<left>40</left>
@@ -810,7 +810,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="label">
 						<left>10</left>
@@ -889,7 +889,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="label">
 						<left>10</left>
@@ -1242,7 +1242,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="label">
 						<left>10</left>
@@ -1321,7 +1321,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="label">
 						<left>10</left>
@@ -1696,7 +1696,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="image">
 						<left>320</left>
@@ -1744,7 +1744,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ShowCustomLabel]</label>
 					</control>
 					<control type="image">
 						<left>320</left>
@@ -1803,7 +1803,7 @@
 					<shadowcolor>black</shadowcolor>
 					<align>left</align>
 					<aligny>center</aligny>
-					<label>$INFO[ListItem.Label]</label>
+					<label>$VAR[ShowCustomLabel]</label>
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>
@@ -1868,7 +1868,7 @@
 					<shadowcolor>black</shadowcolor>
 					<align>left</align>
 					<aligny>center</aligny>
-					<label>$INFO[ListItem.Label]</label>
+					<label>$VAR[ShowCustomLabel]</label>
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>
@@ -1918,7 +1918,7 @@
 					<shadowcolor>black</shadowcolor>
 					<align>left</align>
 					<aligny>center</aligny>
-					<label>$INFO[ListItem.Label]</label>
+					<label>$VAR[ShowCustomLabel]</label>
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>
@@ -1968,7 +1968,7 @@
 					<shadowcolor>black</shadowcolor>
 					<align>left</align>
 					<aligny>center</aligny>
-					<label>$INFO[ListItem.Label]</label>
+					<label>$VAR[ShowCustomLabel]</label>
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -743,3 +743,36 @@ msgstr ""
 msgctxt "#31964"
 msgid "Profile avatar"
 msgstr ""
+
+#. What kind of title will be shown
+#: /720p/DialogVideoInfo.xml
+#: /720p/SkinSettings.xml 
+msgctxt "#31171"
+msgid "What title to display"
+msgstr "" 
+
+#. Default Kodi behauviour - means Localised title usually (ListItem.Title)
+#: /720p/DialogVideoInfo.xml
+#: /720p/SkinSettings.xml 
+msgctxt "#31172"
+msgid "No changes"
+msgstr "" 
+
+#: /720p/DialogVideoInfo.xml
+#: /720p/SkinSettings.xml 
+msgctxt "#31173"
+msgid "Original title (Localised title)"
+msgstr "" 
+
+#: /720p/DialogVideoInfo.xml
+#: /720p/SkinSettings.xml 
+msgctxt "#31174"
+msgid "Localised title (Original title)"
+msgstr "" 
+
+#. Original title - ListItem.OriginalTitle
+#: /720p/DialogVideoInfo.xml
+#: /720p/SkinSettings.xml 
+msgctxt "#31175"
+msgid "Just Original title"
+msgstr "" 


### PR DESCRIPTION
Very usefull switch, when you use parser able to parse both _Original_ and _Localised_ titles. [Kodi PR](https://github.com/xbmc/xbmc/pull/19435) was sucessfuly merged to current master (Nexus), so sort method is also available for OriginalTitle.  POC [video](https://streamable.com/kgvjj9) .