### PR TITLE
Honor spoiler settings on home view

### DIFF
--- a/720p/IncludesHomeRecentlyAdded.xml
+++ b/720p/IncludesHomeRecentlyAdded.xml
@@ -217,7 +217,7 @@
 							<width>220</width>
 							<height>155</height>
 							<aspectratio>scale</aspectratio>
-							<texture background="true">$INFO[ListItem.Art(thumb)]</texture>
+							<texture background="true">$VAR[PosterThumb]</texture>
 							<bordertexture border="5">button-nofocus.png</bordertexture>
 							<bordersize>5</bordersize>
 						</control>
@@ -263,7 +263,7 @@
 							<width>220</width>
 							<height>155</height>
 							<aspectratio>scale</aspectratio>
-							<texture background="true">$INFO[ListItem.Art(thumb)]</texture>
+							<texture background="true">$VAR[PosterThumb]</texture>
 							<bordertexture border="5">folder-focus.png</bordertexture>
 							<bordersize>5</bordersize>
 							<visible>Control.HasFocus(8001)</visible>
@@ -274,7 +274,7 @@
 							<width>220</width>
 							<height>155</height>
 							<aspectratio>scale</aspectratio>
-							<texture>$INFO[ListItem.Art(thumb)]</texture>
+							<texture>$VAR[PosterThumb]</texture>
 							<bordertexture border="5">button-nofocus.png</bordertexture>
 							<bordersize>5</bordersize>
 							<visible>!Control.HasFocus(8001)</visible>


### PR DESCRIPTION
Currently episode images are always shown on the home page. This PR fixes that behavior an hides it when configured.