### PR TITLE
Automatically hide OSD when unPause video

### DIFF
--- a/720p/VideoOSD.xml
+++ b/720p/VideoOSD.xml
@@ -104,6 +104,7 @@
 				<alttexturefocus>OSDPlayFO.png</alttexturefocus>
 				<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
 				<onclick>PlayerControl(Play)</onclick>
+				<onclick condition="Player.Paused">Dialog.Close(VideoOSD)</onclick>
 				<enable>Player.PauseEnabled</enable>
 				<animation effect="fade" start="100" end="50" time="75" condition="!Player.PauseEnabled">Conditional</animation>
 			</control>


### PR DESCRIPTION
Saves one button press, which is immediatelly done when resume Video media.