### PR TITLE
Use new v21 tags for slider control's disabled appearance

### DIFF
--- a/720p/Defaults.xml
+++ b/720p/Defaults.xml
@@ -180,8 +180,10 @@
 		<sliderwidth>150</sliderwidth>
 		<sliderheight>20</sliderheight>
 		<texturesliderbar>osd_slider_bg.png</texturesliderbar>
+		<texturesliderbardisabled colordiffuse="40FFFFFF">osd_slider_bg.png</texturesliderbardisabled>
 		<textureslidernib>osd_slider_nibNF.png</textureslidernib>
 		<textureslidernibfocus>osd_slider_nib.png</textureslidernibfocus>
+		<textureslidernibdisabled colordiffuse="40FFFFFF">osd_slider_nib.png</textureslidernibdisabled>
 		<font>font12</font>
 		<textcolor>white</textcolor>
 		<disabledcolor>grey3</disabledcolor>


### PR DESCRIPTION
Use the new tags texturesliderbardisabled and textureslidernibdisabled added in Kodi v21 for more consistent disabled look of the slider bar in settings.

* Apply diffuse color to match the style of other disabled controls

Used the same diffuse color as disabled textures of other controls in Confluence for simplicity.
Picked osd_slider_bg instead of osd_slider_bgNF because the extra alpha makes it almost invisible.

Tested on v21 (change is visible) and v20 (new tags are ignored and there is no effect).

Enabled:
![image](https://github.com/xbmc/skin.confluence/assets/489377/1aa814c0-7b02-433c-ab5b-1c094ab91784)

Before PR (slider partly disabled):
![image](https://github.com/xbmc/skin.confluence/assets/489377/e500f86e-c39c-4ae4-84b9-4eac64ef08fe)

After PR (fully disabled):
![image](https://github.com/xbmc/skin.confluence/assets/489377/a0427332-6364-477e-9717-4190b9ae6ced)

