### PR TITLE
Add new custom dialog providing access to play speed/3D

### DIFF
--- a/1080p/VideoOSD.xml
+++ b/1080p/VideoOSD.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">100</defaultcontrol>
-	<onload condition="!VideoPlayer.Content(LiveTV)">SetFocus(202)</onload>
+	<onload condition="!VideoPlayer.Content(LiveTV)">SetFocus(105)</onload>
 	<include>dialogeffect</include>
 	<depth>DepthOSD</depth>
 	<coordinates>
@@ -44,11 +44,13 @@
 		<control type="grouplist" id="100">
 			<left>488</left>
 			<top>90r</top>
+			<onleft>207</onleft>
+			<onright>201</onright>
 			<orientation>horizontal</orientation>
 			<itemgap>0</itemgap>
 			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDSubtitleSettings) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVRChannelGuide)]</visible>
-			<control type="button" id="300">
+			<control type="button" id="101">
 				<width>83</width>
 				<height>83</height>
 				<label>210</label>
@@ -58,7 +60,7 @@
 				<onclick>PlayerControl(Previous)</onclick>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
-			<control type="button" id="301">
+			<control type="button" id="102">
 				<width>83</width>
 				<height>83</height>
 				<label>209</label>
@@ -68,7 +70,7 @@
 				<onclick>PlayerControl(Next)</onclick>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
-			<control type="button" id="200">
+			<control type="button" id="103">
 				<width>83</width>
 				<height>83</height>
 				<label>210</label>
@@ -78,7 +80,7 @@
 				<onclick>PlayerControl(Previous)</onclick>
 				<visible>!VideoPlayer.Content(LiveTV)</visible>
 			</control>
-			<control type="button" id="201">
+			<control type="button" id="104">
 				<width>83</width>
 				<height>83</height>
 				<label>31354</label>
@@ -89,7 +91,7 @@
 				<animation effect="fade" start="100" end="50" time="75" condition="!Player.SeekEnabled">Conditional</animation>
 				<onclick>PlayerControl(Rewind)</onclick>
 			</control>
-			<control type="togglebutton" id="202">
+			<control type="togglebutton" id="105">
 				<width>83</width>
 				<height>83</height>
 				<label>31351</label>
@@ -100,12 +102,11 @@
 				<usealttexture>Player.Paused | Player.Forwarding | Player.Rewinding</usealttexture>
 				<alttexturefocus>OSDPlayFO.png</alttexturefocus>
 				<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
-				<onup condition="Player.TempoEnabled">400</onup>
 				<onclick>PlayerControl(Play)</onclick>
 				<enable>Player.PauseEnabled</enable>
 				<animation effect="fade" start="100" end="50" time="75" condition="!Player.PauseEnabled">Conditional</animation>
 			</control>
-			<control type="button" id="203">
+			<control type="button" id="106">
 				<width>83</width>
 				<height>83</height>
 				<label>31352</label>
@@ -114,7 +115,7 @@
 				<texturenofocus>OSDStopNF.png</texturenofocus>
 				<onclick>PlayerControl(Stop)</onclick>
 			</control>
-			<control type="button" id="204">
+			<control type="button" id="107">
 				<width>83</width>
 				<height>83</height>
 				<label>31353</label>
@@ -125,7 +126,7 @@
 				<animation effect="fade" start="100" end="50" time="75" condition="!Player.SeekEnabled">Conditional</animation>
 				<onclick>PlayerControl(Forward)</onclick>
 			</control>
-			<control type="button" id="205">
+			<control type="button" id="108">
 				<width>83</width>
 				<height>83</height>
 				<label>209</label>
@@ -135,112 +136,7 @@
 				<onclick>PlayerControl(Next)</onclick>
 				<visible>!VideoPlayer.Content(LiveTV)</visible>
 			</control>
-			<control type="button" id="306">
-				<width>83</width>
-				<height>83</height>
-				<label>19019</label>
-				<font />
-				<texturefocus>OSDChannelListFO.png</texturefocus>
-				<texturenofocus>OSDChannelListNF.png</texturenofocus>
-				<onclick>ActivateWindow(PVROSDChannels)</onclick>
-				<onclick>Dialog.Close(VideoOSD)</onclick>
-				<visible>VideoPlayer.Content(LiveTV)</visible>
-			</control>
-			<control type="button" id="307">
-				<width>83</width>
-				<height>83</height>
-				<label>$LOCALIZE[19029]$INFO[VideoPlayer.ChannelName, - ]</label>
-				<font />
-				<texturefocus>OSDepgFO.png</texturefocus>
-				<texturenofocus>OSDepgNF.png</texturenofocus>
-				<onclick>ActivateWindow(PVRChannelGuide)</onclick>
-				<onclick>Dialog.Close(VideoOSD)</onclick>
-				<visible>VideoPlayer.Content(LiveTV)</visible>
-			</control>
-			<control type="button" id="350">
-				<width>83</width>
-				<height>83</height>
-				<label>31356</label>
-				<font />
-				<texturefocus>OSDTeleTextFO.png</texturefocus>
-				<texturenofocus>OSDTeleTextNF.png</texturenofocus>
-				<onclick>ActivateWindow(Teletext)</onclick>
-				<visible>VideoPlayer.Content(LiveTV)</visible>
-			</control>
-			<control type="image" id="2200">
-				<width>405</width>
-				<texture />
-				<visible>VideoPlayer.HasMenu + !VideoPlayer.Content(LiveTV)</visible>
-			</control>
-			<control type="image" id="2300">
-				<width>240</width>
-				<texture />
-				<visible>VideoPlayer.Content(LiveTV)</visible>
-			</control>
-			<control type="image" id="2600">
-				<width>488</width>
-				<texture />
-				<visible>!VideoPlayer.Content(LiveTV) + !VideoPlayer.HasMenu</visible>
-			</control>
-			<control type="button" id="255">
-				<enable>VideoPlayer.IsStereoscopic</enable>
-				<animation effect="fade" start="100" end="0" time="75" condition="!VideoPlayer.IsStereoscopic">Conditional</animation>
-				<width>83</width>
-				<height>83</height>
-				<label>36501</label>
-				<font />
-				<texturefocus>OSDStereoscopicFO.png</texturefocus>
-				<texturenofocus>OSDStereoscopicNF.png</texturenofocus>
-				<onup>501</onup>
-			</control>
-			<control type="button" id="250">
-				<width>83</width>
-				<height>83</height>
-				<label>31356</label>
-				<font />
-				<texturefocus>OSDSubtitlesFO.png</texturefocus>
-				<texturenofocus>OSDSubtitlesNF.png</texturenofocus>
-				<onclick>ActivateWindow(OSDSubtitleSettings)</onclick>
-			</control>
-			<control type="button" id="251">
-				<width>83</width>
-				<height>83</height>
-				<label>13395</label>
-				<font />
-				<texturefocus>OSDVideoFO.png</texturefocus>
-				<texturenofocus>OSDVideoNF.png</texturenofocus>
-				<onclick>ActivateWindow(OSDVideoSettings)</onclick>
-			</control>
-			<control type="button" id="252">
-				<width>83</width>
-				<height>83</height>
-				<label>13396</label>
-				<font />
-				<texturefocus>OSDAudioFO.png</texturefocus>
-				<texturenofocus>OSDAudioNF.png</texturenofocus>
-				<onclick>ActivateWindow(OSDAudioSettings)</onclick>
-			</control>
-			<control type="button" id="253">
-				<width>83</width>
-				<height>83</height>
-				<label>298</label>
-				<font />
-				<texturefocus>OSDBookmarksFO.png</texturefocus>
-				<texturenofocus>OSDBookmarksNF.png</texturenofocus>
-				<onclick>ActivateWindow(VideoBookmarks)</onclick>
-				<visible>!VideoPlayer.Content(LiveTV)</visible>
-			</control>
-			<control type="button" id="254">
-				<width>83</width>
-				<height>83</height>
-				<label>31355</label>
-				<font />
-				<texturefocus>OSDDvdFO.png</texturefocus>
-				<texturenofocus>OSDDvdNF.png</texturenofocus>
-				<onclick>PlayerControl(ShowVideoMenu)</onclick>
-				<visible>!VideoPlayer.Content(LiveTV) + VideoPlayer.HasMenu</visible>
-			</control>
-			<control type="togglebutton" id="353">
+			<control type="togglebutton" id="109">
 				<width>83</width>
 				<height>83</height>
 				<label>264</label>
@@ -256,205 +152,110 @@
 				<animation effect="fade" start="100" end="50" time="75" condition="!PVR.CanRecordPlayingChannel">Conditional</animation>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
+			<control type="button" id="110">
+				<width>83</width>
+				<height>83</height>
+				<label>19019</label>
+				<font />
+				<texturefocus>OSDChannelListFO.png</texturefocus>
+				<texturenofocus>OSDChannelListNF.png</texturenofocus>
+				<onclick>ActivateWindow(PVROSDChannels)</onclick>
+				<onclick>Dialog.Close(VideoOSD)</onclick>
+				<visible>VideoPlayer.Content(LiveTV)</visible>
+			</control>
+			<control type="button" id="111">
+				<width>83</width>
+				<height>83</height>
+				<label>$LOCALIZE[19029]$INFO[VideoPlayer.ChannelName, - ]</label>
+				<font />
+				<texturefocus>OSDepgFO.png</texturefocus>
+				<texturenofocus>OSDepgNF.png</texturenofocus>
+				<onclick>ActivateWindow(PVRChannelGuide)</onclick>
+				<onclick>Dialog.Close(VideoOSD)</onclick>
+				<visible>VideoPlayer.Content(LiveTV)</visible>
+			</control>
 		</control>
-		<control type="button" id="410">
-			<description>Fake button for mouse control</description>
-			<left>501</left>
-			<bottom>90</bottom>
-			<width>384</width>
-			<height>375</height>
-			<label />
-			<font />
-			<texturenofocus />
-			<texturefocus />
-			<animation effect="slide" start="0,0" end="83,0" time="0" condition="VideoPlayer.Content(LiveTV)">Conditional</animation>
-			<visible>Control.HasFocus(410) | Control.HasFocus(202) | ControlGroup(400).HasFocus</visible>
-		</control>
-		<control type="button" id="520">
-			<description>Fake button for mouse control</description>
-			<right>300</right>
-			<bottom>90</bottom>
-			<width>384</width>
-			<height>315</height>
-			<label />
-			<font />
-			<texturenofocus />
-			<texturefocus />
-			<animation effect="slide" start="0,0" end="83,0" time="0" condition="VideoPlayer.Content(LiveTV)">Conditional</animation>
-			<visible>Control.HasFocus(520) | Control.HasFocus(255) | ControlGroup(500).HasFocus</visible>
-		</control>
-		<control type="grouplist" id="400">
-			<depth>DepthOSD+</depth>
-			<visible>Player.TempoEnabled + ![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDSubtitleSettings) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVRChannelGuide)] + [Control.HasFocus(202) | ControlGroup(400).HasFocus | Control.HasFocus(410)]</visible>
-			<animation effect="fade" time="150">VisibleChange</animation>
-			<animation effect="slide" start="0,0" end="83,0" time="0" condition="VideoPlayer.Content(LiveTV)">Conditional</animation>
-			<left>501</left>
-			<bottom>68</bottom>
-			<width>384</width>
-			<height>210</height>
+		<control type="grouplist" id="200">
+			<right>20</right>
+			<top>90r</top>
+			<onleft>111</onleft>
+			<onright>101</onright>
+			<orientation>horizontal</orientation>
+			<align>right</align>
 			<itemgap>0</itemgap>
-			<orientation>vertical</orientation>
-			<include>VisibleFadeEffect</include>
-			<control type="group">
-				<description>Header</description>
-				<width>384</width>
-				<height>60</height>
-				<control type="image">
-					<description>Header</description>
-					<left>0</left>
-					<top>0</top>
-					<width>384</width>
-					<height>60</height>
-					<texture border="20,18,20,0">SubMenuBack-Header.png</texture>
-				</control>
-				<control type="label">
-					<left>0</left>
-					<top>30</top>
-					<width>384</width>
-					<height>23</height>
-					<font>font12</font>
-					<label>31022</label>
-					<textcolor>blue</textcolor>
-					<align>center</align>
-					<aligny>center</aligny>
-				</control>
-			</control>
-			<control type="group">
-				<width>384</width>
-				<height>60</height>
-				<control type="image">
-					<width>384</width>
-					<height>60</height>
-					<texture border="25,5,25,5">SubMenuBack-MiddleNF.png</texture>
-				</control>
-				<control type="label">
-					<left>45</left>
-					<width>195</width>
-					<height>60</height>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<label>$INFO[Player.playspeed]</label>
-				</control>
-				<control type="button" id="504">
-					<top>14</top>
-					<left>248</left>
-					<width>50</width>
-					<height>33</height>
-					<texturefocus>scroll-down-focus-2.png</texturefocus>
-					<texturenofocus>scroll-down-2.png</texturenofocus>
-					<onleft>505</onleft>
-					<onright>505</onright>
-					<onup>202</onup>
-					<ondown>202</ondown>
-					<onclick>PlayerControl(TempoDown)</onclick>
-				</control>
-				<control type="button" id="505">
-					<top>14</top>
-					<left>297</left>
-					<width>50</width>
-					<height>33</height>
-					<texturefocus>scroll-up-focus-2.png</texturefocus>
-					<texturenofocus>scroll-up-2.png</texturenofocus>
-					<onleft>504</onleft>
-					<onright>504</onright>
-					<onup>202</onup>
-					<ondown>202</ondown>
-					<onclick>PlayerControl(TempoUp)</onclick>
-				</control>
-			</control>
-			<control type="image" id="549">
-				<description>Footer</description>
-				<width>384</width>
-				<height>78</height>
-				<texture border="20,0,20,50">SubMenuBack-Footer.png</texture>
-			</control>
-		</control>
-		<control type="grouplist" id="500">
-			<depth>DepthOSD+</depth>
-			<visible>videoplayer.isstereoscopic + ![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDSubtitleSettings) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVRChannelGuide)] + [Control.HasFocus(255) | ControlGroup(500).HasFocus | Control.HasFocus(520)]</visible>
 			<animation effect="fade" time="150">VisibleChange</animation>
-			<animation effect="slide" start="0,0" end="83,0" time="0" condition="![VideoPlayer.HasMenu | VideoPlayer.Content(LiveTV)]">Conditional</animation>
-			<animation effect="slide" start="0,0" end="83,0" time="0" condition="VideoPlayer.Content(LiveTV)">Conditional</animation>
-			<right>300</right>
-			<bottom>68</bottom>
-			<width>384</width>
-			<height>330</height>
-			<itemgap>0</itemgap>
-			<onleft>100</onleft>
-			<onright>100</onright>
-			<onup>255</onup>
-			<ondown>255</ondown>
-			<orientation>vertical</orientation>
-			<include>VisibleFadeEffect</include>
-			<control type="group">
-				<description>Header</description>
-				<width>384</width>
-				<height>60</height>
-				<control type="image">
-					<description>Header</description>
-					<left>0</left>
-					<top>0</top>
-					<width>384</width>
-					<height>60</height>
-					<texture border="20,18,20,0">SubMenuBack-Header.png</texture>
-				</control>
-				<control type="label">
-					<left>0</left>
-					<top>30</top>
-					<width>384</width>
-					<height>23</height>
-					<font>font12</font>
-					<label>36501</label>
-					<textcolor>blue</textcolor>
-					<align>center</align>
-					<aligny>center</aligny>
-				</control>
+			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDSubtitleSettings) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVRChannelGuide)]</visible>
+			<control type="button" id="201">
+				<enable>VideoPlayer.IsStereoscopic</enable>
+				<animation effect="fade" start="100" end="0" time="75" condition="!VideoPlayer.IsStereoscopic">Conditional</animation>
+				<width>83</width>
+				<height>83</height>
+				<label>36501</label>
+				<font />
+				<texturefocus>OSDStereoscopicFO.png</texturefocus>
+				<texturenofocus>OSDStereoscopicNF.png</texturenofocus>
+				<onclick>SetProperty(optionsdialog_content,3d,home)</onclick>
+				<onclick>SetProperty(optionsdialog_header,$LOCALIZE[36501],home)</onclick>
+				<onclick>ActivateWindow(1114)</onclick>
+<!--				<onup>501</onup> -->
 			</control>
-			<control type="radiobutton" id="503">
-				<height>60</height>
-				<width>384</width>
-				<textoffsetx>45</textoffsetx>
-				<aligny>center</aligny>
-				<font>font13</font>
-				<label>31362</label>
-				<radioposx>300</radioposx>
-				<texturefocus border="25,5,25,5">SubMenuBack-MiddleFO.png</texturefocus>
-				<texturenofocus border="25,5,25,5">SubMenuBack-MiddleNF.png</texturenofocus>
-				<onclick>ToggleStereoMode</onclick>
-				<selected>Integer.IsGreater(System.StereoscopicMode,0)</selected>
-				<pulseonselect>false</pulseonselect>
+			<control type="button" id="202">
+				<width>83</width>
+				<height>83</height>
+				<label>31356</label>
+				<font />
+				<texturefocus>OSDSubtitlesFO.png</texturefocus>
+				<texturenofocus>OSDSubtitlesNF.png</texturenofocus>
+				<onclick>ActivateWindow(OSDSubtitleSettings)</onclick>
 			</control>
-			<control type="button" id="502">
-				<height>60</height>
-				<width>384</width>
-				<aligny>center</aligny>
-				<font>font13</font>
-				<textoffsetx>45</textoffsetx>
-				<texturefocus border="25,5,25,5">SubMenuBack-MiddleFO.png</texturefocus>
-				<texturenofocus border="25,5,25,5">SubMenuBack-MiddleNF.png</texturenofocus>
-				<pulseonselect>false</pulseonselect>
-				<label>31361</label>
-				<onclick>StereoMode</onclick>
+			<control type="button" id="203">
+				<width>83</width>
+				<height>83</height>
+				<label>13395</label>
+				<font />
+				<texturefocus>OSDVideoFO.png</texturefocus>
+				<texturenofocus>OSDVideoNF.png</texturenofocus>
+				<onclick>ActivateWindow(OSDVideoSettings)</onclick>
 			</control>
-			<control type="radiobutton" id="501">
-				<height>60</height>
-				<width>384</width>
-				<textoffsetx>45</textoffsetx>
-				<aligny>center</aligny>
-				<font>font13</font>
-				<label>31360</label>
-				<radioposx>300</radioposx>
-				<texturefocus border="25,5,25,5">SubMenuBack-MiddleFO.png</texturefocus>
-				<texturenofocus border="25,5,25,5">SubMenuBack-MiddleNF.png</texturenofocus>
-				<onclick>StereoModeToMono</onclick>
-				<selected>String.IsEqual(System.StereoscopicMode,9)</selected>
-				<pulseonselect>false</pulseonselect>
+			<control type="button" id="204">
+				<width>83</width>
+				<height>83</height>
+				<label>13396</label>
+				<font />
+				<texturefocus>OSDAudioFO.png</texturefocus>
+				<texturenofocus>OSDAudioNF.png</texturenofocus>
+				<onclick>ActivateWindow(OSDAudioSettings)</onclick>
 			</control>
-			<control type="image" id="549">
-				<description>Footer</description>
-				<width>384</width>
-				<height>78</height>
-				<texture border="20,0,20,50">SubMenuBack-Footer.png</texture>
+			<control type="button" id="205">
+				<width>83</width>
+				<height>83</height>
+				<label>298</label>
+				<font />
+				<texturefocus>OSDBookmarksFO.png</texturefocus>
+				<texturenofocus>OSDBookmarksNF.png</texturenofocus>
+				<onclick>ActivateWindow(VideoBookmarks)</onclick>
+				<visible>!VideoPlayer.Content(LiveTV)</visible>
+			</control>
+			<control type="button" id="206">
+				<width>83</width>
+				<height>83</height>
+				<label>31355</label>
+				<font />
+				<texturefocus>OSDDvdFO.png</texturefocus>
+				<texturenofocus>OSDDvdNF.png</texturenofocus>
+				<onclick>PlayerControl(ShowVideoMenu)</onclick>
+				<visible>!VideoPlayer.Content(LiveTV) + VideoPlayer.HasMenu</visible>
+			</control>
+			<control type="button" id="207">
+				<width>83</width>
+				<height>83</height>
+				<label>31355</label>
+				<font/>
+				<texturefocus>OSDPresetSettingsFO.png</texturefocus>
+				<texturenofocus>OSDPresetSettingsNF.png</texturenofocus>
+				<onclick>SetProperty(optionsdialog_content,options,home)</onclick>
+				<onclick>SetProperty(optionsdialog_header,$LOCALIZE[33063],home)</onclick>
+				<onclick>ActivateWindow(1114)</onclick>
 			</control>
 		</control>
 	</controls>

--- a/1080p/custom_OptionsDialog.xml
+++ b/1080p/custom_OptionsDialog.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<window id="1114" type="dialog">
+	<defaultcontrol always="true">11000</defaultcontrol>
+	<onload condition="String.IsEqual(window(home).Property(optionsdialog_content),options)">SetFocus(11100)</onload>
+	<onload condition="String.IsEqual(window(home).Property(optionsdialog_content),3d)">SetFocus(11200)</onload>
+	<include>dialogeffect</include>
+	<onunload>ClearProperty(optionsdialog_header,Home)</onunload>
+	<onunload>ClearProperty(optionsdialog_content,Home)</onunload>
+	<coordinates>
+		<left>360</left>
+		<top>213</top>
+	</coordinates>
+	<controls>
+		<control type="group" id="11000">
+			<centerleft>50%</centerleft>
+			<centertop>50%</centertop>
+			<animation effect="fade" time="150">VisibleChange</animation>
+			<include content="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="1200" />
+				<param name="DialogBackgroundHeight" value="330" />
+				<param name="DialogHeaderWidth" value="1080" />
+				<param name="DialogHeaderLabel" value="$INFO[Window(home).Property(optionsdialog_header)]" />
+				<param name="DialogHeaderId" value="1" />
+				<param name="CloseButtonLeft" value="1065" />
+				<param name="CloseButtonNav" value="10" />
+			</include>
+			<control type="grouplist" id="11100">
+				<visible>String.IsEqual(window(home).Property(optionsdialog_content),options)</visible>
+				<animation effect="fade" time="150">VisibleChange</animation>
+				<left>53</left>
+				<top>105</top>
+				<width>1095</width>
+				<height>192</height>
+				<itemgap>6</itemgap>
+				<onleft>11100</onleft>
+				<onright>11100</onright>
+				<onup>11100</onup>
+				<ondown>11100</ondown>
+				<orientation>vertical</orientation>
+				<control type="button" id="11101">
+					<height>60</height>
+					<width>1095</width>
+					<texturefocus border="5">button-focus2.png</texturefocus>
+					<label>31022</label>
+					<onclick>Dialog.Close(all)</onclick>
+					<onclick>ActivateWindow(1115)</onclick>
+					<enable>Player.TempoEnabled</enable>
+				</control>
+				<control type="button" id="11102">
+					<height>60</height>
+					<width>1095</width>
+					<label>10116</label>
+					<texturefocus border="5">button-focus2.png</texturefocus>
+					<onclick>Dialog.Close(all)</onclick>
+					<onclick>ActivateWindow(playerprocessinfo)</onclick>
+					<onclick>SetFocus(207)</onclick>
+				</control>
+				<control type="button" id="11103">
+					<height>60</height>
+					<width>1095</width>
+					<label>36560</label>
+					<texturefocus border="5">button-focus2.png</texturefocus>
+					<onclick>Dialog.Close(1114)</onclick>
+					<onclick>ActivateWindow(osdcmssettings)</onclick>
+					<visible>System.HasCMS</visible>
+				</control>
+			</control>
+			<control type="grouplist" id="11200">
+				<visible>String.IsEqual(window(home).Property(optionsdialog_content),3d)</visible>
+				<animation effect="fade" time="150">VisibleChange</animation>
+				<left>53</left>
+				<top>105</top>
+				<width>1095</width>
+				<height>192</height>
+				<itemgap>6</itemgap>
+				<onleft>11200</onleft>
+				<onright>11200</onright>
+				<onup>11200</onup>
+				<ondown>11200</ondown>
+				<orientation>vertical</orientation>
+				<control type="radiobutton" id="11201">
+					<height>60</height>
+					<width>1095</width>
+					<aligny>center</aligny>
+					<label>31362</label>
+					<radioposx>1040</radioposx>
+					<texturefocus border="5">button-focus2.png</texturefocus>
+					<onclick>ToggleStereoMode</onclick>
+					<selected>Integer.IsGreater(System.StereoscopicMode,0)</selected>
+				</control>
+				<control type="button" id="11202">
+					<height>60</height>
+					<width>1095</width>
+					<aligny>center</aligny>
+					<texturefocus border="5">button-focus2.png</texturefocus>
+					<label>31361</label>
+					<label2>[B]$INFO[VideoPlayer.StereoscopicMode][/B]</label2>
+					<onclick>StereoMode</onclick>
+				</control>
+				<control type="radiobutton" id="11203">
+					<height>60</height>
+					<width>1095</width>
+					<aligny>center</aligny>
+					<label>31360</label>
+					<radioposx>1040</radioposx>
+					<texturefocus border="5">button-focus2.png</texturefocus>
+					<onclick>StereoModeToMono</onclick>
+					<selected>String.IsEqual(System.StereoscopicMode,9)</selected>
+				</control>
+			</control>
+		</control>
+	</controls>
+</window>
+

--- a/1080p/custom_PlaySpeed.xml
+++ b/1080p/custom_PlaySpeed.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<window id="1115" type="dialog">
+	<onunload>ActivateWindow(videoosd)</onunload>
+	<depth>DepthDialog+</depth>
+	<defaultcontrol>11</defaultcontrol>
+	<animation effect="fade" start="0" end="100" time="150">WindowOpen</animation>
+	<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>m
+	<controls>
+		<control type="group">
+			<left>20</left>
+			<top>-9</top>
+			<control type="image">
+				<left>0</left>
+				<top>0</top>
+				<width>240</width>
+				<height>105</height>
+				<colordiffuse>EEFFFFFF</colordiffuse>
+				<texture border="12">OverlayDialogBackground.png</texture>
+			</control>
+			<control type="label">
+				<description>Play speed header label</description>
+				<left>20</left>
+				<top>15</top>
+				<width>200</width>
+				<height>30</height>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12_title</font>
+				<textcolor>blue</textcolor>
+				<scroll>true</scroll>
+				<label>31022</label>
+			</control>
+			<control type="label">
+				<description>Play speed label</description>
+				<left>20</left>
+				<top>50</top>
+				<width>80</width>
+				<height>35</height>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font13_title</font>
+				<textcolor>grey2</textcolor>
+				<label>$INFO[Player.playspeed]</label>
+			</control>
+			<control type="button" id="11">
+				<left>120</left>
+				<top>50</top>
+				<width>50</width>
+				<height>35</height>
+				<onleft>12</onleft>
+				<onright>12</onright>
+				<texturefocus>scroll-down-focus-2.png</texturefocus>
+				<texturenofocus>scroll-down-2.png</texturenofocus>
+				<onclick>PlayerControl(TempoDown)</onclick>
+			</control>
+			<control type="button" id="12">
+				<left>170</left>
+				<top>50</top>
+				<width>50</width>
+				<height>35</height>
+				<onleft>11</onleft>
+				<onright>11</onright>
+				<texturefocus>scroll-up-focus-2.png</texturefocus>
+				<texturenofocus>scroll-up-2.png</texturenofocus>
+				<onclick>PlayerControl(TempoUp)</onclick>
+			</control>
+		</control>
+	</controls>
+</window>


### PR DESCRIPTION
Remove tool tip menu's for Play Speed and Stereoscopic 3D mode.

Add new `custom_OptionsDialog.xml` this provides a new Options menu and provide the menu for Stereoscopic 3D mode options.

New `Options` menu has:

**Play speed** (moved from old tool tip menu)
**Player process info** (new osd access to this)
**Colour Management** (new osd access to this)

![image](https://github.com/user-attachments/assets/ed1cd66d-7e95-4893-910b-a8c5a9001b91)

Add new `custom_PlaySpeed.xml` to provide **Play speed** control

![image](https://github.com/user-attachments/assets/988e3b0d-8599-4225-b534-c337c294e5c9)

New `Stereoscopic 3D mode` menu

![image](https://github.com/user-attachments/assets/4579b26a-e530-4613-a108-1c0280fb870b)

I also the took the oportunity to clean up the grouplists and button id's in `VideoOSD.xml`

The group of buttons to the left are in Grouplist id `100`
All button in the grouplist are in id range `101 `to `111 `to show they belong to Grouplist id `100`

The group of buttoms to the right are now in a seperate Grouplist id `200`
All button in the grouplist are in id range `201 `to `207 `to show they belong to Grouplist id `200`

![image](https://github.com/user-attachments/assets/18213eba-554c-4a56-994e-1c6ed14128f9)
