### PR TITLE
Teletext button fix [Omega]

### DIFF
--- a/1080p/VideoOSD.xml
+++ b/1080p/VideoOSD.xml
@@ -174,11 +174,21 @@
 				<onclick>Dialog.Close(VideoOSD)</onclick>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
+			<control type="button" id="112">
+				<width>83</width>
+				<height>83</height>
+				<label>31356</label>
+				<font/>
+				<texturefocus>OSDTeleTextFO.png</texturefocus>
+				<texturenofocus>OSDTeleTextNF.png</texturenofocus>
+				<onclick>ActivateWindow(Teletext)</onclick>
+				<visible>VideoPlayer.Content(LiveTV)</visible>
+			</control>
 		</control>
 		<control type="grouplist" id="200">
 			<right>20</right>
 			<top>90r</top>
-			<onleft>111</onleft>
+			<onleft>112</onleft>
 			<onright>101</onright>
 			<orientation>horizontal</orientation>
 			<align>right</align>
@@ -197,7 +207,6 @@
 				<onclick>SetProperty(optionsdialog_content,3d,home)</onclick>
 				<onclick>SetProperty(optionsdialog_header,$LOCALIZE[36501],home)</onclick>
 				<onclick>ActivateWindow(1114)</onclick>
-<!--				<onup>501</onup> -->
 			</control>
 			<control type="button" id="202">
 				<width>83</width>


### PR DESCRIPTION
Fix https://github.com/xbmc/skin.confluence/issues/286

Missing teletext button after osd button refactor contained in https://github.com/xbmc/skin.confluence/pull/284

There was also a stray commented out onup I got to remove.