### PR TITLE
Playerprocessinfo improvements

### DIFF
--- a/1080p/DialogPlayerProcessInfo.xml
+++ b/1080p/DialogPlayerProcessInfo.xml
@@ -20,7 +20,7 @@
 			</control>
 			<control type="label">
 				<description>Header</description>
-				<left>75</left>
+				<left>35</left>
 				<top>15</top>
 				<width>848</width>
 				<height>38</height>
@@ -32,9 +32,9 @@
 			</control>
 			<control type="label">
 				<description>Hardware decoding</description>
-				<left>75</left>
+				<left>35</left>
 				<top>60</top>
-				<width>248</width>
+				<width>278</width>
 				<height>38</height>
 				<label>$LOCALIZE[31010]:</label>
 				<align>left</align>
@@ -44,7 +44,7 @@
 			</control>
 			<control type="label">
 				<description>Hardware decoding value</description>
-				<left>330</left>
+				<left>320</left>
 				<top>60</top>
 				<width>675</width>
 				<height>38</height>
@@ -58,7 +58,7 @@
 			</control>
 			<control type="label">
 				<description>Hardware decoding value</description>
-				<left>330</left>
+				<left>320</left>
 				<top>60</top>
 				<width>675</width>
 				<height>38</height>
@@ -72,9 +72,9 @@
 			</control>
 			<control type="label">
 				<description>Decoder</description>
-				<left>75</left>
+				<left>35</left>
 				<top>98</top>
-				<width>248</width>
+				<width>278</width>
 				<height>38</height>
 				<label>$LOCALIZE[31012]:</label>
 				<align>left</align>
@@ -84,12 +84,12 @@
 			</control>
 			<control type="label">
 				<description>Decoder value</description>
-				<left>330</left>
+				<left>312</left>
 				<top>98</top>
 				<width>675</width>
 				<height>38</height>
 				<scroll>true</scroll>
-				<label fallback="1446">$INFO[Player.Process(videodecoder)]$INFO[Player.Process(pixformat),$COMMA ]</label>
+				<label fallback="1446">$INFO[Player.Process(videodecoder), ]$VAR[VideoHWDecoder, (,)]</label>
 				<align>left</align>
 				<aligny>center</aligny>
 				<font>font12</font>
@@ -97,9 +97,9 @@
 			</control>
 			<control type="label">
 				<description>Deinterlace</description>
-				<left>75</left>
+				<left>35</left>
 				<top>135</top>
-				<width>248</width>
+				<width>278</width>
 				<height>38</height>
 				<label>$LOCALIZE[16038]:</label>
 				<align>left</align>
@@ -109,7 +109,7 @@
 			</control>
 			<control type="label">
 				<description>Deinterlace value</description>
-				<left>330</left>
+				<left>320</left>
 				<top>135</top>
 				<width>675</width>
 				<height>38</height>
@@ -122,9 +122,9 @@
 			</control>
 			<control type="label">
 				<description>Resolution</description>
-				<left>75</left>
+				<left>35</left>
 				<top>173</top>
-				<width>248</width>
+				<width>278</width>
 				<height>38</height>
 				<label>$LOCALIZE[169]:</label>
 				<align>left</align>
@@ -134,12 +134,12 @@
 			</control>
 			<control type="label">
 				<description>Resolution value</description>
-				<left>330</left>
+				<left>320</left>
 				<top>173</top>
 				<width>675</width>
 				<height>38</height>
 				<scroll>true</scroll>
-				<label fallback="1446">$INFO[Player.Process(videowidth),,x]$INFO[Player.Process(videoheight)]$INFO[Player.Process(videoscantype)]$INFO[Player.Process(videodar),$COMMA , AR]$INFO[Player.Process(videofps),$COMMA , FPS]</label>
+				<label fallback="1446">$INFO[Player.Process(videowidth),,x]$INFO[Player.Process(videoheight)]$INFO[Player.Process(videoscantype)]$INFO[Player.Process(videodar),$COMMA , AR]$INFO[Player.Process(videofps),$COMMA , fps]$INFO[VideoPlayer.VideoBitrate,$COMMA , kb/s]</label>
 				<align>left</align>
 				<aligny>center</aligny>
 				<font>font12</font>
@@ -147,7 +147,7 @@
 			</control>
 			<control type="label">
 				<description>Header</description>
-				<left>75</left>
+				<left>35</left>
 				<top>218</top>
 				<width>848</width>
 				<height>38</height>
@@ -159,9 +159,9 @@
 			</control>
 			<control type="label">
 				<description>Decoder</description>
-				<left>75</left>
-				<top>263</top>
-				<width>248</width>
+				<left>35</left>
+				<top>259</top>
+				<width>278</width>
 				<height>38</height>
 				<label>$LOCALIZE[31012]:</label>
 				<align>left</align>
@@ -171,8 +171,8 @@
 			</control>
 			<control type="label">
 				<description>Decoder value</description>
-				<left>330</left>
-				<top>263</top>
+				<left>320</left>
+				<top>259</top>
 				<width>675</width>
 				<height>38</height>
 				<scroll>true</scroll>
@@ -184,9 +184,9 @@
 			</control>
 			<control type="label">
 				<description>Channels</description>
-				<left>75</left>
-				<top>300</top>
-				<width>248</width>
+				<left>35</left>
+				<top>298</top>
+				<width>278</width>
 				<height>38</height>
 				<label>$LOCALIZE[19019]:</label>
 				<align>left</align>
@@ -196,8 +196,8 @@
 			</control>
 			<control type="label">
 				<description>Channels value</description>
-				<left>330</left>
-				<top>300</top>
+				<left>320</left>
+				<top>298</top>
 				<width>675</width>
 				<height>38</height>
 				<scroll>true</scroll>
@@ -209,8 +209,8 @@
 			</control>
 			<control type="label">
 				<description>Header</description>
-				<left>75</left>
-				<top>345</top>
+				<left>35</left>
+				<top>339</top>
 				<width>848</width>
 				<height>38</height>
 				<label>$LOCALIZE[138]</label>
@@ -219,13 +219,337 @@
 				<font>font13_title</font>
 				<textcolor>blue</textcolor>
 			</control>
+			
 			<control type="label">
-				<description>CPU</description>
-				<left>75</left>
-				<top>390</top>
+			<visible>System.HasAddon(service.coreelec.settings)</visible>
+				<left>35</left>
+				<top>382</top>
+				<width>278</width>
+				<height>38</height>
+				<label>$LOCALIZE[31151]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+			<visible>System.HasAddon(service.coreelec.settings)</visible>
+				<left>320</left>
+				<top>382</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[Player.CacheLevel] %</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+			<visible>!System.HasAddon(service.coreelec.settings)</visible>
+				<left>35</left>
+				<top>382</top>
+				<width>278</width>
+				<height>38</height>
+				<label>$LOCALIZE[31152]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+			<visible>!System.HasAddon(service.coreelec.settings)</visible>
+				<left>320</left>
+				<top>382</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[System.ScreenResolution]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<description>Memory</description>
+				<left>35</left>
+				<top>418</top>
+				<width>278</width>
+				<height>38</height>
+				<label>$LOCALIZE[31153]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<description>Memory value</description>
+				<left>320</left>
+				<top>418</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[system.memory(used)] / $INFO[system.memory(total)] - $INFO[system.memory(used.percent)]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="progress">
+				<description>RAM BAR</description>
+				<left>35</left>
+				<top>455</top>
+				<width>880</width>
+				<height>18</height>
+				<info>system.memory(used)</info>
+			</control>
+		</control>
+		<control type="group">
+			<depth>DepthOSD+</depth>
+			<left>965</left>
+			<visible>!System.HasAddon(service.coreelec.settings)</visible>
+			<visible>![VideoPlayer.Content(LiveTV) + system.getbool(pvrplayback.signalquality)]</visible>
+			<control type="label">
+				<description>Header</description>
+				<left>35</left>
+				<top>15</top>
+				<width>848</width>
+				<height>38</height>
+				<label>$LOCALIZE[31154]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font13_title</font>
+				<textcolor>blue</textcolor>
+			</control>
+			<control type="label">
+				<description>Video source type</description>
+				<left>35</left>
+				<top>60</top>
 				<width>248</width>
 				<height>38</height>
-				<label>$LOCALIZE[13271]</label>
+				<label>$LOCALIZE[31155]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<description>Video source type value</description>
+				<left>320</left>
+				<top>60</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$VAR[HDRcodectypeVar]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>Player.HasVideo</visible>
+			</control>
+			<control type="label">
+				<description>Video codec</description>
+				<left>35</left>
+				<top>98</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31156]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<description>Videocodec</description>
+				<left>320</left>
+				<top>98</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[VideoPlayer.VideoCodec]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>Player.HasVideo</visible>
+			</control>
+			<control type="label">
+				<description>Videoresolution</description>
+				<left>35</left>
+				<top>135</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31157]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<description>Videoresolution</description>
+				<left>320</left>
+				<top>135</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[VideoPlayer.VideoResolution]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>Player.HasVideo</visible>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>172</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31158]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>320</left>
+				<top>172</top>
+				<width>875</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$VAR[AudioCodecVar]  $VAR[AudioChannelsVar]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>210</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31159]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+				<visible>!String.IsEmpty(VideoPlayer.AudioLanguage)</visible>
+			</control>
+			<control type="label">
+				<left>320</left>
+				<top>210</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[VideoPlayer.AudioLanguage]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>!String.IsEmpty(VideoPlayer.AudioLanguage)</visible>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>248</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31160]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+				<visible>!String.IsEmpty(VideoPlayer.SubtitlesLanguage)</visible>
+			</control>
+			<control type="label">
+				<left>320</left>
+				<top>248</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[VideoPlayer.SubtitlesLanguage]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>VideoPlayer.SubtitlesEnabled</visible>
+			</control>
+			<control type="label">
+				<left>320</left>
+				<top>248</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[VideoPlayer.SubtitlesLanguage] $LOCALIZE[31161]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>!VideoPlayer.SubtitlesEnabled</visible>
+			</control>
+			<control type="label">
+				<description>Header</description>
+				<left>35</left>
+				<top>293</top>
+				<width>848</width>
+				<height>38</height>
+				<label>$LOCALIZE[31162]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font13_title</font>
+				<textcolor>blue</textcolor>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>338</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31163]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>320</left>
+				<top>338</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[System.CpuFrequency]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>376</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31164]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>320</left>
+				<top>376</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[System.FPS] fps</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<description>Cache</description>
+				<left>35</left>
+				<top>414</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31165]</label>
 				<align>left</align>
 				<aligny>center</aligny>
 				<font>font12</font>
@@ -233,8 +557,235 @@
 			</control>
 			<control type="label">
 				<description>CPU value</description>
-				<left>330</left>
-				<top>390</top>
+				<left>320</left>
+				<top>414</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[Player.CacheLevel] %</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="progress">
+				<description>Cache BAR</description>
+				<left>35</left>
+				<top>455</top>
+				<width>880</width>
+				<height>18</height>
+				<info>Player.CacheLevel</info>
+			</control>
+		</control>
+		<control type="group">
+			<depth>DepthOSD+</depth>
+			<left>965</left>
+			<visible>System.HasAddon(service.coreelec.settings)</visible>
+			<visible>![VideoPlayer.Content(LiveTV) + system.getbool(pvrplayback.signalquality)]</visible>
+			<control type="label">
+				<description>Header</description>
+				<left>35</left>
+				<top>15</top>
+				<width>848</width>
+				<height>38</height>
+				<label>$LOCALIZE[31166]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font13_title</font>
+				<textcolor>blue</textcolor>
+			</control>
+			<control type="label">
+				<description>Video source type</description>
+				<left>35</left>
+				<top>60</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31167]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<description>Video source type value</description>
+				<left>290</left>
+				<top>60</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$VAR[HDRcodectypeVar]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>Player.HasVideo</visible>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>98</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31168]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>290</left>
+				<top>98</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[Player.Process(amlogic.pixformat)]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>135</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31169]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>290</left>
+				<top>135</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[Player.Process(amlogic.eoft_gamut)]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>172</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31171]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>290</left>
+				<top>172</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[System.FPS] fps</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>210</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31170]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>290</left>
+				<top>210</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[Player.Process(amlogic.displaymode)]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<description>Header</description>
+				<left>35</left>
+				<top>293</top>
+				<width>848</width>
+				<height>38</height>
+				<label>$LOCALIZE[31172]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font13_title</font>
+				<textcolor>blue</textcolor>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>338</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31163]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>290</left>
+				<top>338</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[System.CpuFrequency]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>376</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31173]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>290</left>
+				<top>376</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[System.CPUTemperature]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+			</control>
+			<control type="label">
+				<description>CPU</description>
+				<left>35</left>
+				<top>414</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31174]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<description>CPU value</description>
+				<left>290</left>
+				<top>414</top>
 				<width>675</width>
 				<height>38</height>
 				<scroll>true</scroll>
@@ -244,39 +795,152 @@
 				<font>font12</font>
 				<textcolor>white</textcolor>
 			</control>
+			<control type="progress">
+				<description>CPU BAR</description>
+				<left>35</left>
+				<top>455</top>
+				<width>880</width>
+				<height>18</height>
+				<info>System.CPUUsage</info>
+			</control>
+		</control>
+		<control type="group">
+			<depth>DepthOSD+</depth>
+			<left>1480</left>
+			<visible>System.HasAddon(service.coreelec.settings)</visible>
+			<visible>![VideoPlayer.Content(LiveTV) + system.getbool(pvrplayback.signalquality)]</visible>		
 			<control type="label">
-				<description>Memory</description>
-				<left>75</left>
-				<top>428</top>
+				<description>Header</description>
+				<left>35</left>
+				<top>15</top>
+				<width>848</width>
+				<height>38</height>
+				<label>$LOCALIZE[31154]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font13_title</font>
+				<textcolor>blue</textcolor>
+			</control>
+			<control type="label">
+				<description>Video source type</description>
+				<left>35</left>
+				<top>60</top>
 				<width>248</width>
 				<height>38</height>
-				<label>$LOCALIZE[31014]:</label>
+				<label>$LOCALIZE[31156]</label>
 				<align>left</align>
 				<aligny>center</aligny>
 				<font>font12</font>
 				<textcolor>grey2</textcolor>
 			</control>
 			<control type="label">
-				<description>Memory value</description>
-				<left>330</left>
-				<top>428</top>
+				<description>Videocodec</description>
+				<left>210</left>
+				<top>60</top>
 				<width>675</width>
 				<height>38</height>
 				<scroll>true</scroll>
-				<label>$INFO[System.Memory(used.percent)]</label>
+				<label>$INFO[VideoPlayer.VideoCodec]  $INFO[VideoPlayer.VideoResolution]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>Player.HasVideo</visible>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>98</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31158]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+			</control>
+			<control type="label">
+				<left>210</left>
+				<top>98</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$VAR[AudioCodecVar]  $VAR[AudioChannelsVar]</label>
 				<align>left</align>
 				<aligny>center</aligny>
 				<font>font12</font>
 				<textcolor>white</textcolor>
 			</control>
+			<control type="label">
+				<left>35</left>
+				<top>135</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31159]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+				<visible>!String.IsEmpty(VideoPlayer.AudioLanguage)</visible>
+			</control>
+			<control type="label">
+				<left>210</left>
+				<top>135</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[VideoPlayer.AudioLanguage]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>!String.IsEmpty(VideoPlayer.AudioLanguage)</visible>
+			</control>
+			<control type="label">
+				<left>35</left>
+				<top>172</top>
+				<width>248</width>
+				<height>38</height>
+				<label>$LOCALIZE[31160]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>grey2</textcolor>
+				<visible>!String.IsEmpty(VideoPlayer.SubtitlesLanguage)</visible>
+			</control>
+			<control type="label">
+				<left>210</left>
+				<top>172</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[VideoPlayer.SubtitlesLanguage]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>VideoPlayer.SubtitlesEnabled</visible>
+			</control>
+			<control type="label">
+				<left>210</left>
+				<top>172</top>
+				<width>675</width>
+				<height>38</height>
+				<scroll>true</scroll>
+				<label>$INFO[VideoPlayer.SubtitlesLanguage] $LOCALIZE[31161]</label>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<textcolor>white</textcolor>
+				<visible>!VideoPlayer.SubtitlesEnabled</visible>
+			</control>
 		</control>
 		<control type="group">
 			<depth>DepthOSD+</depth>
 			<visible>VideoPlayer.Content(LiveTV) + system.getbool(pvrplayback.signalquality)</visible>
-			<left>960</left>
+			<left>965</left>
 			<control type="label">
 				<description>Header</description>
-				<left>75</left>
+				<left>35</left>
 				<top>15</top>
 				<width>848</width>
 				<height>38</height>
@@ -288,7 +952,7 @@
 			</control>
 			<control type="label">
 				<description>Backend</description>
-				<left>75</left>
+				<left>35</left>
 				<top>60</top>
 				<width>248</width>
 				<height>38</height>
@@ -300,7 +964,7 @@
 			</control>
 			<control type="label">
 				<description>Backend value</description>
-				<left>330</left>
+				<left>290</left>
 				<top>60</top>
 				<width>675</width>
 				<height>38</height>
@@ -313,7 +977,7 @@
 			</control>
 			<control type="label">
 				<description>Device</description>
-				<left>75</left>
+				<left>35</left>
 				<top>98</top>
 				<width>248</width>
 				<height>38</height>
@@ -325,7 +989,7 @@
 			</control>
 			<control type="label">
 				<description>Device value</description>
-				<left>330</left>
+				<left>290</left>
 				<top>98</top>
 				<width>675</width>
 				<height>38</height>
@@ -338,7 +1002,7 @@
 			</control>
 			<control type="label">
 				<description>Status</description>
-				<left>75</left>
+				<left>35</left>
 				<top>135</top>
 				<width>248</width>
 				<height>38</height>
@@ -350,7 +1014,7 @@
 			</control>
 			<control type="label">
 				<description>Status value</description>
-				<left>330</left>
+				<left>290</left>
 				<top>135</top>
 				<width>675</width>
 				<height>38</height>
@@ -363,7 +1027,7 @@
 			</control>
 			<control type="label">
 				<description>Signal</description>
-				<left>75</left>
+				<left>35</left>
 				<top>173</top>
 				<width>248</width>
 				<height>38</height>
@@ -375,7 +1039,7 @@
 			</control>
 			<control type="progress">
 				<description>Progressbar</description>
-				<left>330</left>
+				<left>290</left>
 				<top>183</top>
 				<width>413</width>
 				<height>21</height>
@@ -395,7 +1059,7 @@
 			</control>
 			<control type="label">
 				<description>SNR</description>
-				<left>75</left>
+				<left>35</left>
 				<top>210</top>
 				<width>248</width>
 				<height>38</height>
@@ -407,7 +1071,7 @@
 			</control>
 			<control type="progress">
 				<description>Progressbar</description>
-				<left>330</left>
+				<left>290</left>
 				<top>221</top>
 				<width>413</width>
 				<height>21</height>
@@ -428,7 +1092,7 @@
 			</control>
 			<control type="label">
 				<description>BER</description>
-				<left>75</left>
+				<left>35</left>
 				<top>248</top>
 				<width>248</width>
 				<height>38</height>
@@ -440,7 +1104,7 @@
 			</control>
 			<control type="label">
 				<description>BER value</description>
-				<left>330</left>
+				<left>290</left>
 				<top>248</top>
 				<width>675</width>
 				<height>38</height>
@@ -453,7 +1117,7 @@
 			</control>
 			<control type="label">
 				<description>UNC</description>
-				<left>75</left>
+				<left>35</left>
 				<top>285</top>
 				<width>248</width>
 				<height>38</height>
@@ -465,7 +1129,7 @@
 			</control>
 			<control type="label">
 				<description>UNC value</description>
-				<left>330</left>
+				<left>290</left>
 				<top>285</top>
 				<width>675</width>
 				<height>38</height>
@@ -478,7 +1142,7 @@
 			</control>
 			<control type="label">
 				<description>Service</description>
-				<left>75</left>
+				<left>35</left>
 				<top>323</top>
 				<width>248</width>
 				<height>38</height>
@@ -490,7 +1154,7 @@
 			</control>
 			<control type="label">
 				<description>Service value</description>
-				<left>330</left>
+				<left>290</left>
 				<top>323</top>
 				<width>675</width>
 				<height>38</height>
@@ -503,7 +1167,7 @@
 			</control>
 			<control type="label">
 				<description>Encryption</description>
-				<left>75</left>
+				<left>35</left>
 				<top>360</top>
 				<width>248</width>
 				<height>38</height>
@@ -515,7 +1179,7 @@
 			</control>
 			<control type="label">
 				<description>Encryption value</description>
-				<left>330</left>
+				<left>290</left>
 				<top>360</top>
 				<width>675</width>
 				<height>38</height>
@@ -528,7 +1192,7 @@
 			</control>
 			<control type="label">
 				<description>Provider</description>
-				<left>75</left>
+				<left>35</left>
 				<top>398</top>
 				<width>248</width>
 				<height>38</height>
@@ -540,7 +1204,7 @@
 			</control>
 			<control type="label">
 				<description>Provider value</description>
-				<left>330</left>
+				<left>290</left>
 				<top>398</top>
 				<width>675</width>
 				<height>38</height>
@@ -553,7 +1217,7 @@
 			</control>
 			<control type="label">
 				<description>Mux</description>
-				<left>75</left>
+				<left>35</left>
 				<top>435</top>
 				<width>248</width>
 				<height>38</height>
@@ -565,7 +1229,7 @@
 			</control>
 			<control type="label">
 				<description>Mux value</description>
-				<left>330</left>
+				<left>290</left>
 				<top>435</top>
 				<width>675</width>
 				<height>38</height>

--- a/1080p/Includes.xml
+++ b/1080p/Includes.xml
@@ -643,6 +643,72 @@
 		<value condition="ListItem.HasVideoVersions">flagging/video/overlay_versions.png</value>
 		<value condition="ListItem.HasVideoExtras">flagging/video/overlay_extras.png</value>
 	</variable>
+	<variable name="OSDHelpTextVar">
+		<value condition="Control.HasFocus(201)">$LOCALIZE[36501]</value>
+		<value condition="Control.HasFocus(2001)">$LOCALIZE[10116]</value>
+		<value condition="Control.HasFocus(202)">$LOCALIZE[24012]</value>
+		<value condition="Control.HasFocus(203)">$LOCALIZE[13395]</value>
+		<value condition="Control.HasFocus(204)">$LOCALIZE[13396]</value>
+		<value condition="Control.HasFocus(205)">$LOCALIZE[298]</value>
+		<value condition="Control.HasFocus(206)">$LOCALIZE[31355]</value>
+		<value condition="Control.HasFocus(207)">$LOCALIZE[1390]</value>
+		<value condition="Control.HasFocus(101)">$LOCALIZE[210]</value>
+		<value condition="Control.HasFocus(102)">$LOCALIZE[209]</value>
+		<value condition="Control.HasFocus(103)">$LOCALIZE[210]</value>
+		<value condition="Control.HasFocus(104)">$LOCALIZE[31354]</value>
+		<value condition="Control.HasFocus(105) + !Player.Paused">$LOCALIZE[36045]</value>
+		<value condition="Control.HasFocus(105) + Player.Paused">$LOCALIZE[208]</value>
+		<value condition="Control.HasFocus(106)">$LOCALIZE[31352]</value>
+		<value condition="Control.HasFocus(107)">$LOCALIZE[31353]</value>
+		<value condition="Control.HasFocus(108)">$LOCALIZE[209]</value>
+		<value condition="Control.HasFocus(109)">$LOCALIZE[264]</value>
+		<value condition="Control.HasFocus(110)">$LOCALIZE[19019]</value>
+		<value condition="Control.HasFocus(111)">$LOCALIZE[19029]$INFO[VideoPlayer.ChannelName, - ]</value>
+	</variable>
+	<variable name="VideoHWDecoder">
+		<value condition="Player.Process(videohwdecoder)">HW</value>
+		<value>SW</value>
+	</variable>
+	<variable name="AudioChannelsVar">
+		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,1)">Mono</value>
+		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,2)">2.0</value>
+		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,3)">2.1</value>
+		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,4)">4.0</value>
+		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,5)">5.0</value>
+		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,6)">5.1</value>
+		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,7)">6.1</value>
+		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,8)">7.1</value>
+		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,10)">9.1</value>
+	</variable>
+	<variable name="AudioCodecVar">
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd) + [String.Contains(Player.Filenameandpath,DTS-X) | String.Contains(Player.Filenameandpath,DTSX)]">DTS - X</value>
+		<value condition="String.IsEqual((VideoPlayer.AudioCodec,dtshd)">DTS-HD MA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma) + [String.Contains(Player.Filenameandpath,DTS-X) | String.Contains(Player.Filenameandpath,DTSX)]">DTS - X</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtsma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_hra)">DTS-HRA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshra)">DTS-HRA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dca) | String.Contains(VideoPlayer.AudioCodec,dts)">DTS</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,truehd) + String.Contains(Player.Filenameandpath,.Atmos.)">Dolby Atmos</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,truehd)">Dolby TrueHD</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,eac3)">Dolby Digital+</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,ac3)">Dolby Digital</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,mp3)">MP3</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,mp2)">MP2</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,mp1)">MP1</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,vorbis)">Vorbis</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,aac)">AAC</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,wmav2)">WMA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,wmapro)">WMA Pro</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm) | String.IsEqual(VideoPlayer.AudioCodec,pcm_bluray) | String.IsEqual(VideoPlayer.AudioCodec,pcm_s16le) | String.IsEqual(VideoPlayer.AudioCodec,pcm_s24le)">PCM</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,cook)">Cook</value>
+	</variable>
+	<variable name="HDRcodectypeVar">
+		<value condition="String.Contains(VideoPlayer.HdrType,dolbyvision)">Dolby Vision</value>
+		<value condition="String.Contains(VideoPlayer.HdrType,hdr10)">HDR</value>
+		<value condition="String.Contains(VideoPlayer.HdrType,hlg">HLG</value>
+		<value condition="String.IsEmpty(VideoPlayer.HdrType)">SDR</value>
+	</variable>
 	<!-- INCLUDES -->
 	<include name="MusicInfoPanel">
 		<control type="panel" id="50">

--- a/1080p/SkinSettings.xml
+++ b/1080p/SkinSettings.xml
@@ -293,6 +293,33 @@
 						<onclick>Skin.SelectBool(31021, 31030|TitleFormat_nothing, 31036|TitleFormat_only, 31034|TitleFormat_1st, 31035|TitleFormat_2nd)</onclick>
 						<label2>$VAR[ShowOriginalName]</label2>
 					</control>
+					<control type="radiobutton" id="1181">
+					    <width>1125</width>
+						<height>60</height>
+						<font>font13</font>
+						<textcolor>grey2</textcolor>
+						<focusedcolor>white</focusedcolor>
+						<texturefocus>MenuItemFO.png</texturefocus>
+						<texturenofocus>MenuItemNF.png</texturenofocus>
+					    <label>$LOCALIZE[31149]</label>
+					    <include>DefaultSettingButton</include>
+					    <selected>Skin.HasSetting(OSDAutoClose)</selected>
+					    <onclick>Skin.ToggleSetting(OSDAutoClose)</onclick>
+				</control>
+				<control type="button" id="1182">
+				        <width>1125</width>
+						<height>60</height>
+						<font>font13</font>
+						<textcolor>grey2</textcolor>
+						<focusedcolor>white</focusedcolor>
+						<texturefocus>MenuItemFO.png</texturefocus>
+						<texturenofocus>MenuItemNF.png</texturenofocus>
+					    <label>$LOCALIZE[31150]</label>
+					    <label2>$VAR[SkinSettingOSDAutoCloseTime]</label2>
+					    <include>DefaultSettingButton</include>
+					    <onclick>Skin.SetNumeric(OSDAutoCloseTime)</onclick>
+					    <enable>Skin.HasSetting(OSDAutoClose)</enable>
+				 </control>
 				</control>
 				<control type="scrollbar" id="60">
 					<left>1590</left>

--- a/1080p/Timers.xml
+++ b/1080p/Timers.xml
@@ -1,2 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<timers></timers>
+<timers>
+    <timer>
+        <name>autoclosevideoosd</name>
+        <description>Timer to auto close the video OSD (if enabled in the skin settings)</description>
+        <start reset="true">Window.IsActive(videoosd) + Skin.HasSetting(OSDAutoClose) + !String.IsEqual(window(home).Property(settingslist_content),osd) + !Window.IsActive(osdsubtitlesettings) + !Window.IsActive(osdaudiosettings) + !Window.IsActive(osdvideosettings) + !Window.IsActive(OSDCMSSettings)</start>
+        <reset>Window.IsActive(videoosd) + !System.IdleTime(1) + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(autoclosevideoosd), 1) | String.IsEqual(window(home).Property(settingslist_content),osd) | Window.IsActive(osdsubtitlesettings) | Window.IsActive(osdaudiosettings) | Window.IsActive(osdvideosettings) | Window.IsActive(OSDCMSSettings)</reset>
+        <stop>!Window.IsActive(videoosd) | String.IsEmpty(Skin.String(OSDAutoCloseTime)) + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(autoclosevideoosd), 4) | !String.IsEmpty(Skin.String(OSDAutoCloseTime)) + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(autoclosevideoosd),Skin.Numeric(OSDAutoCloseTime))</stop>
+        <onstop>Dialog.Close(videoosd)</onstop>
+    </timer>
+</timers>

--- a/1080p/VideoOSD.xml
+++ b/1080p/VideoOSD.xml
@@ -25,6 +25,20 @@
 			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>system.getbool(input.enablemouse) + ![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDSubtitleSettings) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks)]</visible>
 		</control>
+					
+			<control type="label">
+				<animation effect="slide" end="0,-20" time="150" condition="VideoPlayer.Content(LiveTV)">conditional</animation>
+				<left>1025</left>
+				<bottom>5</bottom>
+				<align>center</align>
+				<aligny>center</aligny>
+				<width>300</width>
+				<height>50</height>
+				<font>font10</font>
+				<textcolor>grey2</textcolor>
+				<label>$VAR[OSDHelpTextVar]</label>
+				<shadowcolor>black</shadowcolor>
+			</control>
 		<control type="slider" id="87">
 			<depth>DepthOSD+</depth>
 			<description>Seek Slider</description>
@@ -174,27 +188,19 @@
 				<onclick>Dialog.Close(VideoOSD)</onclick>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
-			<control type="button" id="112">
-				<width>83</width>
-				<height>83</height>
-				<label>31356</label>
-				<font/>
-				<texturefocus>OSDTeleTextFO.png</texturefocus>
-				<texturenofocus>OSDTeleTextNF.png</texturenofocus>
-				<onclick>ActivateWindow(Teletext)</onclick>
-				<visible>VideoPlayer.Content(LiveTV)</visible>
-			</control>
 		</control>
 		<control type="grouplist" id="200">
 			<right>20</right>
 			<top>90r</top>
-			<onleft>112</onleft>
+			<onleft>111</onleft>
 			<onright>101</onright>
 			<orientation>horizontal</orientation>
 			<align>right</align>
 			<itemgap>0</itemgap>
 			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDSubtitleSettings) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVRChannelGuide)]</visible>
+
+			
 			<control type="button" id="201">
 				<enable>VideoPlayer.IsStereoscopic</enable>
 				<animation effect="fade" start="100" end="0" time="75" condition="!VideoPlayer.IsStereoscopic">Conditional</animation>
@@ -207,6 +213,16 @@
 				<onclick>SetProperty(optionsdialog_content,3d,home)</onclick>
 				<onclick>SetProperty(optionsdialog_header,$LOCALIZE[36501],home)</onclick>
 				<onclick>ActivateWindow(1114)</onclick>
+<!--				<onup>501</onup> -->
+			</control>
+			<control type="button" id="2001">
+				<width>83</width>
+				<height>83</height>
+				<label>Playerprocessinfo</label>
+				<font />
+				<texturefocus>osdppinfof.png</texturefocus>
+				<texturenofocus>osdppinfo.png</texturenofocus>
+				<onclick>ActivateWindow(playerprocessinfo)</onclick>
 			</control>
 			<control type="button" id="202">
 				<width>83</width>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -429,7 +429,139 @@ msgctxt "#31148"
 msgid "Hide - Search"
 msgstr ""
 
-#empty strings from id 31149 to 31199
+#: /1080p/SkinSettings.xml
+#. Setting Automatically close video OSD
+msgctxt "#31149"
+msgid "Automatically close video OSD"
+msgstr ""
+
+#: /1080p/SkinSettings.xml
+#. Setting auto close time for video osd
+msgctxt "#31150"
+msgid "Video OSD autoclose time (seconds)"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31151"
+msgid "Videostream cache:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31152"
+msgid "Output resolution:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31153"
+msgid "Memory usage:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31154"
+msgid "Codec informations"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31155"
+msgid "Video type:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31156"
+msgid "Video codec:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31157"
+msgid "Video resolution:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31158"
+msgid "Audio codec:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31159"
+msgid "Audio:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31160"
+msgid "Subtitle:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31161"
+msgid " (disabled)"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31162"
+msgid "CPU & fps & cache informations"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31163"
+msgid "CPU frequency:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31164"
+msgid "System fps:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31165"
+msgid "Video stream cache:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31166"
+msgid "Video informations"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31167"
+msgid "Video source type:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31168"
+msgid "Pixel format:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31169"
+msgid "EOTF & Gamut:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31170"
+msgid "Display mode:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31171"
+msgid "System fps:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31172"
+msgid "CPU informations"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31173"
+msgid "CPU temp:"
+msgstr ""
+
+#: /1080p/DialogPlayerProcessInfo.xml
+msgctxt "#31174"
+msgid "CPU usage:"
+msgstr ""
+
+#empty strings from id 31175 to 31199
 
 msgctxt "#31200"
 msgid "Shortcuts"

--- a/language/resource.language.hu_hu/strings.po
+++ b/language/resource.language.hu_hu/strings.po
@@ -77,7 +77,7 @@ msgstr "Inaktív"
 
 msgctxt "#31012"
 msgid "Decoder"
-msgstr "Dekodoló"
+msgstr "Dekóder"
 
 msgctxt "#31013"
 msgid "Audio process information"
@@ -101,19 +101,19 @@ msgstr "Nem elérhető"
 
 msgctxt "#31018"
 msgid "Set default startup item"
-msgstr ""
+msgstr "Indításkor ezzel a menüvel induljon"
 
 msgctxt "#31019"
 msgid "Press 'Up' to set this item as default"
-msgstr ""
+msgstr "Nyomd a "Fel" gombot, a beállításhoz"
 
 msgctxt "#31020"
 msgid "Game saves"
-msgstr ""
+msgstr "Játékmentések"
 
 msgctxt "#31021"
 msgid "Movie title format"
-msgstr ""
+msgstr "Filmcím formátum"
 
 # empty strings from id 31018 to 31021
 msgctxt "#31022"
@@ -150,7 +150,7 @@ msgstr "Fanart"
 
 msgctxt "#31030"
 msgid "No changes"
-msgstr ""
+msgstr "Nincs változtatás"
 
 msgctxt "#31031"
 msgid "Pic thumbs"
@@ -166,23 +166,23 @@ msgstr "Infó"
 
 msgctxt "#31034"
 msgid "Original title (Localised title)"
-msgstr ""
+msgstr "Eredeti cím (magyar cím)"
 
 msgctxt "#31035"
 msgid "Localised title (Original title)"
-msgstr ""
+msgstr "Magyar cím (eredeti cím)"
 
 msgctxt "#31036"
 msgid "Just Original title"
-msgstr ""
+msgstr "Csak eredeti cím"
 
 msgctxt "#31037"
 msgid "Select + X"
-msgstr ""
+msgstr "Kiválaszt + x"
 
 msgctxt "#31038"
 msgid "Select + Start"
-msgstr ""
+msgstr "Kiválaszt + start"
 
 msgctxt "#31039"
 msgid "Actions"
@@ -194,7 +194,7 @@ msgstr "Most játszva"
 
 msgctxt "#31041"
 msgid "Select + Right Stick"
-msgstr ""
+msgstr "Kiválaszt + jobb gomb"
 
 msgctxt "#31042"
 msgid "PLAYING"
@@ -402,15 +402,121 @@ msgstr "lejátszáslista mappa:"
 
 msgctxt "#31146"
 msgid "Hide home screen buttons"
-msgstr ""
+msgstr "főmenü gombok elrejtése"
 
 msgctxt "#31147"
 msgid "Hide - Favourites"
-msgstr ""
+msgstr "Kedvencek gomb elrejtése"
 
 msgctxt "#31148"
 msgid "Hide - Search"
-msgstr ""
+msgstr "Keresés gomb elrejtése"
+
+msgctxt "#31149"
+msgid "Automatically close video OSD"
+msgstr "Videó OSD automatikus bezárása"
+
+msgctxt "#31150"
+msgid "Video OSD autoclose time (seconds)"
+msgstr "Bezárás idejének beállítása"
+
+msgctxt "#31151"
+msgid "Videostream cache:"
+msgstr "Videó előtöltés:"
+
+msgctxt "#31152"
+msgid "Output resolution:"
+msgstr "Kimenő felbontás:"
+
+msgctxt "#31153"
+msgid "Memory usage:"
+msgstr "Memória használat:"
+
+msgctxt "#31154"
+msgid "Codec informations"
+msgstr "Kodek információk"
+
+msgctxt "#31155"
+msgid "Video type:"
+msgstr "Videó típus:"
+
+msgctxt "#31156"
+msgid "Video codec:"
+msgstr "Videó kodek:"
+
+msgctxt "#31157"
+msgid "Video resolution:"
+msgstr "Videó felbontás:"
+
+msgctxt "#31158"
+msgid "Audio codec:"
+msgstr "Hang kodek:"
+
+msgctxt "#31159"
+msgid "Audio:"
+msgstr "Nyelv:"
+
+msgctxt "#31160"
+msgid "Subtitle:"
+msgstr "Felirat:"
+
+msgctxt "#31161"
+msgid " (disabled)"
+msgstr " (ki)"
+
+msgctxt "#31162"
+msgid "CPU & fps & cache informations"
+msgstr "CPU & fps & előtöltés információk"
+
+msgctxt "#31163"
+msgid "CPU frequency:"
+msgstr "CPU frekvencia:"
+
+msgctxt "#31164"
+msgid "System fps:"
+msgstr "Rendszer fps:"
+
+msgctxt "#31165"
+msgid "Video stream cache:"
+msgstr "Videó előtöltés:"
+
+msgctxt "#31166"
+msgid "Video informations"
+msgstr "Videó információk"
+
+msgctxt "#31167"
+msgid "Video source type:"
+msgstr "Videó forrás típus:"
+
+msgctxt "#31168"
+msgid "Pixel format:"
+msgstr "Pixel formátum:"
+
+msgctxt "#31169"
+msgid "EOTF & Gamut:"
+msgstr "EOTF & Gamut:"
+
+msgctxt "#31170"
+msgid "Display mode:"
+msgstr "Kijelző mód:"
+
+msgctxt "#31171"
+msgid "System fps:"
+msgstr "Rendszer fps:"
+
+msgctxt "#31172"
+msgid "CPU informations"
+msgstr "Processzor információk"
+
+msgctxt "#31173"
+msgid "CPU temp:"
+msgstr "CPU hőmérséktet:"
+
+msgctxt "#31174"
+msgid "CPU usage:"
+msgstr "CPU használat:"
+
+#empty strings from id 31175 to 31199
 
 msgctxt "#31200"
 msgid "Shortcuts"


### PR DESCRIPTION
I made some improvement in confluence skin, updated some button in video osd, for better resolution.

Added to auto hide video osd , in the skin settings. 

Added playerprocessinfo button to the video osd.

Added the button OSDHelpText for video osdbuttons.

Added and some values, and  reorganized the playerprocessinfo, to fit for kodi, and for coreelec.

![1conf](https://github.com/user-attachments/assets/de53dd1e-120a-4764-bd5a-46512658f1c9)

![2conf](https://github.com/user-attachments/assets/b5aea282-0aa9-408c-87df-84283b0982c8)

![3conf](https://github.com/user-attachments/assets/13ea053d-d492-4d4d-912a-8349d5382349)
