### PR TITLE
Add play button on music info dialog

### DIFF
--- a/1080p/DialogMusicInfo.xml
+++ b/1080p/DialogMusicInfo.xml
@@ -196,6 +196,11 @@
 					<onright>9000</onright>
 					<onup>50</onup>
 					<ondown>49</ondown>
+					<control type="button" id="8">
+						<description>Play</description>
+						<include>ButtonInfoDialogsCommonValues</include>
+						<label />
+					</control>
 					<control type="button" id="6">
 						<description>Refresh</description>
 						<include>ButtonInfoDialogsCommonValues</include>


### PR DESCRIPTION
Hi,
with this PR i want to add the Play button on the music info dialog like on Estuary, it's an handy thing when you dig into the artist discography.

I'm not an expert skinner and it's my first contribution, so let me know if the proposed solution could be ok :)

Here some screens

![{ECDBA961-9DF0-4147-AA18-DF22E885D1DE}](https://github.com/user-attachments/assets/fb26eeeb-a82a-4bab-af6f-b646a94d600d)

![{4831678D-B3C4-4807-9254-74DCC2DB61A1}](https://github.com/user-attachments/assets/9e32c0f9-e55e-4bdb-a010-47013f7feea3)



