### PR TITLE
[Master] Refactor player process

### DIFF
--- a/1080p/DialogPlayerProcessInfo.xml
+++ b/1080p/DialogPlayerProcessInfo.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">100</defaultcontrol>
+	<defaultcontrol always="true">10000</defaultcontrol>
 	<include>dialogeffect</include>
 	<depth>DepthOSD</depth>
+	<onunload>ClearProperty(PlayerInfoDialogFocus,Home)</onunload>
 	<coordinates>
 		<left>0</left>
 		<top>0</top>
@@ -12,569 +13,496 @@
 			<depth>DepthOSD+</depth>
 			<control type="image">
 				<description>media info background image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>1920</width>
-				<height>488</height>
+				<left>-30</left>
+				<top>350r</top>
+				<width>1980</width>
+				<height>350</height>
 				<texture>black-back.png</texture>
 			</control>
-			<control type="label">
-				<description>Header</description>
-				<left>75</left>
-				<top>15</top>
-				<width>848</width>
-				<height>38</height>
-				<label>$LOCALIZE[31007]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font13_title</font>
-				<textcolor>blue</textcolor>
+			<control type="grouplist" id="10000">
+				<top>403r</top>
+				<include>HomeSubMenuCommonValues</include>
+				<!-- Buttons for the grouplist -->
+				<control type="image">
+					<width>53</width>
+					<height>53</height>
+					<texture colordiffuse="B3FFFFFF" border="0,0,0,3" flipy="true" flipx="true">HomeSubEnd.png</texture>
+				</control>
+				<control type="button" id="10001">
+					<height>53</height>
+					<width>270</width>
+					<textwidth>240</textwidth>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12</font>
+					<textcolor>grey2</textcolor>
+					<focusedcolor>white</focusedcolor>
+					<scroll>true</scroll>
+					<texturefocus border="5">HomeSubFO.png</texturefocus>
+					<texturenofocus colordiffuse="B3FFFFFF" border="5">HomeSubNF.png</texturenofocus>
+					<pulseonselect>false</pulseonselect>
+					<label>$LOCALIZE[31310]</label>
+					<visible>VideoPlayer.Content(livetv)</visible>
+					<onfocus>SetProperty(PlayerInfoDialogFocus,10001,Home)</onfocus>
+				</control>
+				<control type="button" id="10002">
+					<height>53</height>
+					<width>270</width>
+					<textwidth>240</textwidth>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12</font>
+					<textcolor>grey2</textcolor>
+					<focusedcolor>white</focusedcolor>
+					<scroll>true</scroll>
+					<texturefocus border="5">HomeSubFO.png</texturefocus>
+					<texturenofocus colordiffuse="B3FFFFFF" border="5">HomeSubNF.png</texturenofocus>
+					<pulseonselect>false</pulseonselect>
+					<label>$LOCALIZE[31311]</label>
+					<onfocus>SetProperty(PlayerInfoDialogFocus,10002,Home)</onfocus>
+				</control>
+				<control type="button" id="10003">
+					<height>53</height>
+					<width>270</width>
+					<textwidth>240</textwidth>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12</font>
+					<textcolor>grey2</textcolor>
+					<focusedcolor>white</focusedcolor>
+					<scroll>true</scroll>
+					<texturefocus border="5">HomeSubFO.png</texturefocus>
+					<texturenofocus colordiffuse="B3FFFFFF" border="5">HomeSubNF.png</texturenofocus>
+					<pulseonselect>false</pulseonselect>
+					<label>$LOCALIZE[31312]</label>
+					<onfocus>SetProperty(PlayerInfoDialogFocus,10003,Home)</onfocus>
+				</control>
+				<control type="button" id="10004">
+					<height>53</height>
+					<width>270</width>
+					<textwidth>240</textwidth>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12</font>
+					<textcolor>grey2</textcolor>
+					<focusedcolor>white</focusedcolor>
+					<scroll>true</scroll>
+					<texturefocus border="5">HomeSubFO.png</texturefocus>
+					<texturenofocus colordiffuse="B3FFFFFF" border="5">HomeSubNF.png</texturenofocus>
+					<pulseonselect>false</pulseonselect>
+					<label>$LOCALIZE[31313]</label>
+					<onfocus>SetProperty(PlayerInfoDialogFocus,10004,Home)</onfocus>
+				</control>
+				<control type="image">
+					<width>53</width>
+					<height>53</height>
+					<texture colordiffuse="B3FFFFFF" border="0,0,0,3" flipy="true">HomeSubEnd.png</texture>
+				</control>
 			</control>
-			<control type="label">
-				<description>Hardware decoding</description>
-				<left>75</left>
-				<top>60</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[31010]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
+			<control type="grouplist">
+				<description>PVR - Left column</description>
+				<left>50</left>
+				<top>340r</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),10001)</visible>
+				<control type="label">
+					<description>Header</description>
+					<width>880</width>
+					<height>38</height>
+					<label>$LOCALIZE[19005]</label>
+					<font>font13_title</font>
+					<textcolor>blue</textcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19099]: [/COLOR]$INFO[PVR.ActStreamServiceName]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19101]: [/COLOR]$INFO[PVR.ActStreamProviderName]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19012]: [/COLOR]$INFO[PVR.ActStreamClient]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19006]: [/COLOR]$INFO[PVR.ActStreamDevice]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19007]: [/COLOR]$INFO[PVR.ActStreamStatus]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19015]: [/COLOR]$INFO[PVR.ActStreamEncryptionName]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
 			</control>
-			<control type="label">
-				<description>Hardware decoding value</description>
-				<left>330</left>
-				<top>60</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$LOCALIZE[19074]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-				<visible>Player.Process(videohwdecoder)</visible>
+			<control type="grouplist">
+				<description>PVR - Right column</description>
+				<left>960</left>
+				<top>340r</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),10001)</visible>
+				<usecontrolcoords>true</usecontrolcoords>
+				<control type="label">
+					<description>Header</description>
+					<width>880</width>
+					<height>38</height>
+					<label>$LOCALIZE[31332]</label>
+					<font>font13_title</font>
+					<textcolor>blue</textcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19010]: [/COLOR]$INFO[PVR.ActStreamBER]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19011]: [/COLOR]$INFO[PVR.ActStreamUNC]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19100]: [/COLOR]$INFO[PVR.ActStreamMux]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19008]: [/COLOR]$INFO[PVR.ActStreamSignal]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="progress">
+					<top>0</top>
+					<left>0</left>
+					<width>880</width>
+					<height>18</height>
+					<info>PVR.ActStreamProgrSignal</info>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19009]: [/COLOR]$INFO[PVR.ActStreamSNR]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="progress">
+					<top>0</top>
+					<left>0</left>
+					<width>880</width>
+					<height>21</height>
+					<info>PVR.ActStreamProgrSNR</info>
+				</control>
 			</control>
-			<control type="label">
-				<description>Hardware decoding value</description>
-				<left>330</left>
-				<top>60</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$LOCALIZE[31011]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-				<visible>!Player.Process(videohwdecoder)</visible>
+			<control type="grouplist">
+				<description>Player info - Left column</description>
+				<left>50</left>
+				<top>340r</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),10002)</visible>
+				<control type="label">
+					<description>Header</description>
+					<width>880</width>
+					<height>38</height>
+					<label>$LOCALIZE[31007]</label>
+					<font>font13_title</font>
+					<textcolor>blue</textcolor>
+				</control>
+				<control type="label">
+					<description>Hardware decoding value</description>
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31010]: [/COLOR]$LOCALIZE[19074]</label>
+					<font>font12</font>
+					<visible>Player.Process(videohwdecoder)</visible>
+				</control>
+				<control type="label">
+					<description>Hardware decoding value</description>
+					<width>880</width>
+					<height>38</height>
+					<scroll>true</scroll>
+					<label>[COLOR grey2]$LOCALIZE[31010]: [/COLOR]$LOCALIZE[31011]</label>
+					<font>font12</font>
+					<visible>!Player.Process(videohwdecoder)</visible>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31012]: [/COLOR]$INFO[Player.Process(videodecoder)]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31339]: [/COLOR]$INFO[Player.Process(videowidth),,x]$INFO[Player.Process(videoheight)]$INFO[Player.Process(videoscantype)]$INFO[Player.Process(videodar),$COMMA , AR]$INFO[Player.Process(videofps),$COMMA , FPS]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31341]: [/COLOR]$INFO[Player.Process(pixformat)]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[16038]: [/COLOR]$INFO[Player.Process(deintmethod)]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31342]: [/COLOR]$INFO[Player.CacheLevel,,%]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="progress">
+					<top>0</top>
+					<left>0</left>
+					<width>880</width>
+					<height>21</height>
+					<info>Player.CacheLevel</info>
+					<visible>Player.HasVideo</visible>
+				</control>
 			</control>
-			<control type="label">
-				<description>Decoder</description>
-				<left>75</left>
-				<top>98</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[31012]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
+			<control type="grouplist">
+				<description>Player info - Right column</description>
+				<left>990</left>
+				<top>340r</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),10002)</visible>
+				<control type="label">
+					<description>Header</description>
+					<width>880</width>
+					<height>38</height>
+					<label>$LOCALIZE[31013]</label>
+					<font>font13_title</font>
+					<textcolor>blue</textcolor>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31339]: [/COLOR]$INFO[Player.Process(audiobitspersample),, bit]$INFO[Player.Process(audiosamplerate),$COMMA , Hz]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31012]: [/COLOR]$INFO[Player.Process(audiodecoder)]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[19019]: [/COLOR]$INFO[Player.Process(audiochannels)]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
 			</control>
-			<control type="label">
-				<description>Decoder value</description>
-				<left>330</left>
-				<top>98</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label fallback="1446">$INFO[Player.Process(videodecoder)]$INFO[Player.Process(pixformat),$COMMA ]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
+			<control type="grouplist">
+				<description>Media info - Left column</description>
+				<left>50</left>
+				<top>340r</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),10003)</visible>
+				<control type="label">
+					<description>Header</description>
+					<width>880</width>
+					<height>38</height>
+					<label>$LOCALIZE[31333]</label>
+					<font>font13_title</font>
+					<textcolor>blue</textcolor>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[21445]: [/COLOR]$INFO[VideoPlayer.VideoCodec]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.VideoCodec)</visible>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31335]: [/COLOR]$INFO[VideoPlayer.VideoResolution]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.VideoResolution)</visible>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[20474]: [/COLOR]$INFO[VideoPlayer.HdrType]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.HdrType)</visible>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[21374]: [/COLOR]$INFO[VideoPlayer.VideoAspect]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.VideoAspect)</visible>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31336]: [/COLOR]$INFO[VideoPlayer.VideoBitrate,, kb/s]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.VideoBitrate)</visible>
+				</control>
 			</control>
-			<control type="label">
-				<description>Deinterlace</description>
-				<left>75</left>
-				<top>135</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[16038]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
+			<control type="grouplist">
+				<description>Media info - Right column</description>
+				<left>990</left>
+				<top>340r</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),10003)</visible>
+				<control type="label">
+					<description>Header</description>
+					<width>880</width>
+					<height>38</height>
+					<label>$LOCALIZE[31334]</label>
+					<font>font13_title</font>
+					<textcolor>blue</textcolor>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[21446]: [/COLOR]$INFO[VideoPlayer.AudioCodec]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.AudioCodec)</visible>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31338]: [/COLOR]$INFO[VideoPlayer.AudioChannels]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.AudioChannels)</visible>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31337]: [/COLOR]$INFO[VideoPlayer.AudioBitrate,, kb/s]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.AudioBitrate)</visible>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31339]: [/COLOR]$INFO[VideoPlayer.AudioLanguage]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.AudioLanguage)</visible>
+				</control>
 			</control>
-			<control type="label">
-				<description>Deinterlace value</description>
-				<left>330</left>
-				<top>135</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label fallback="1446">$INFO[Player.Process(deintmethod)]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Resolution</description>
-				<left>75</left>
-				<top>173</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[169]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Resolution value</description>
-				<left>330</left>
-				<top>173</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label fallback="1446">$INFO[Player.Process(videowidth),,x]$INFO[Player.Process(videoheight)]$INFO[Player.Process(videoscantype)]$INFO[Player.Process(videodar),$COMMA , AR]$INFO[Player.Process(videofps),$COMMA , FPS]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Header</description>
-				<left>75</left>
-				<top>218</top>
-				<width>848</width>
-				<height>38</height>
-				<label>$LOCALIZE[31013]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font13_title</font>
-				<textcolor>blue</textcolor>
-			</control>
-			<control type="label">
-				<description>Decoder</description>
-				<left>75</left>
-				<top>263</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[31012]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Decoder value</description>
-				<left>330</left>
-				<top>263</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label fallback="1446">$INFO[Player.Process(audiodecoder)]$INFO[Player.Process(audiobitspersample),$COMMA , bit]$INFO[Player.Process(audiosamplerate),$COMMA , Hz]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Channels</description>
-				<left>75</left>
-				<top>300</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19019]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Channels value</description>
-				<left>330</left>
-				<top>300</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label fallback="1446">$INFO[Player.Process(audiochannels)]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Header</description>
-				<left>75</left>
-				<top>345</top>
-				<width>848</width>
-				<height>38</height>
-				<label>$LOCALIZE[138]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font13_title</font>
-				<textcolor>blue</textcolor>
-			</control>
-			<control type="label">
-				<description>CPU</description>
-				<left>75</left>
-				<top>390</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[13271]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>CPU value</description>
-				<left>330</left>
-				<top>390</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[System.CpuUsage]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Memory</description>
-				<left>75</left>
-				<top>428</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[31014]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Memory value</description>
-				<left>330</left>
-				<top>428</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[System.Memory(used.percent)]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-		</control>
-		<control type="group">
-			<depth>DepthOSD+</depth>
-			<visible>VideoPlayer.Content(LiveTV) + system.getbool(pvrplayback.signalquality)</visible>
-			<left>960</left>
-			<control type="label">
-				<description>Header</description>
-				<left>75</left>
-				<top>15</top>
-				<width>848</width>
-				<height>38</height>
-				<label>$LOCALIZE[19005]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font13_title</font>
-				<textcolor>blue</textcolor>
-			</control>
-			<control type="label">
-				<description>Backend</description>
-				<left>75</left>
-				<top>60</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19012]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Backend value</description>
-				<left>330</left>
-				<top>60</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[PVR.ActStreamClient]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Device</description>
-				<left>75</left>
-				<top>98</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19006]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Device value</description>
-				<left>330</left>
-				<top>98</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[PVR.ActStreamDevice]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Status</description>
-				<left>75</left>
-				<top>135</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19007]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Status value</description>
-				<left>330</left>
-				<top>135</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[PVR.ActStreamStatus]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Signal</description>
-				<left>75</left>
-				<top>173</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19008]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="progress">
-				<description>Progressbar</description>
-				<left>330</left>
-				<top>183</top>
-				<width>413</width>
-				<height>21</height>
-				<info>PVR.ActStreamProgrSignal</info>
-			</control>
-			<control type="label">
-				<description>Signal value</description>
-				<left>818</left>
-				<top>173</top>
-				<width>270</width>
-				<height>38</height>
-				<label>$INFO[PVR.ActStreamSignal]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>SNR</description>
-				<left>75</left>
-				<top>210</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19009]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="progress">
-				<description>Progressbar</description>
-				<left>330</left>
-				<top>221</top>
-				<width>413</width>
-				<height>21</height>
-				<overlaytexture />
-				<info>PVR.ActStreamProgrSNR</info>
-			</control>
-			<control type="label">
-				<description>SNR value</description>
-				<left>818</left>
-				<top>210</top>
-				<width>270</width>
-				<height>38</height>
-				<label>$INFO[PVR.ActStreamSNR]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>BER</description>
-				<left>75</left>
-				<top>248</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19010]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>BER value</description>
-				<left>330</left>
-				<top>248</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[PVR.ActStreamBER]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>UNC</description>
-				<left>75</left>
-				<top>285</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19011]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>UNC value</description>
-				<left>330</left>
-				<top>285</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[PVR.ActStreamUNC]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Service</description>
-				<left>75</left>
-				<top>323</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19099]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Service value</description>
-				<left>330</left>
-				<top>323</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[PVR.ActStreamServiceName]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Encryption</description>
-				<left>75</left>
-				<top>360</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19015]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Encryption value</description>
-				<left>330</left>
-				<top>360</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[PVR.ActStreamEncryptionName]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Provider</description>
-				<left>75</left>
-				<top>398</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19101]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Provider value</description>
-				<left>330</left>
-				<top>398</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[PVR.ActStreamProviderName]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
-			</control>
-			<control type="label">
-				<description>Mux</description>
-				<left>75</left>
-				<top>435</top>
-				<width>248</width>
-				<height>38</height>
-				<label>$LOCALIZE[19100]:</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>grey2</textcolor>
-			</control>
-			<control type="label">
-				<description>Mux value</description>
-				<left>330</left>
-				<top>435</top>
-				<width>675</width>
-				<height>38</height>
-				<scroll>true</scroll>
-				<label>$INFO[PVR.ActStreamMux]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font12</font>
-				<textcolor>white</textcolor>
+			<control type="grouplist">
+				<description>System info</description>
+				<left>50</left>
+				<top>340r</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),10004)</visible>
+				<control type="label">
+					<description>Header</description>
+					<width>880</width>
+					<height>38</height>
+					<label>$LOCALIZE[138]</label>
+					<font>font13_title</font>
+					<textcolor>blue</textcolor>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31343]: [/COLOR]$INFO[System.ScreenResolution]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(System.ScreenResolution)</visible>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31344]: [/COLOR]$INFO[System.FPS,, fps]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(System.FPS)</visible>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31345]: [/COLOR]$INFO[System.CPUTemperature]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(System.CPUTemperature)</visible>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[31014]: [/COLOR]$INFO[system.memory(used)]$INFO[system.memory(total), / ]$INFO[system.memory(used.percent), - ]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(system.memory(used))</visible>
+				</control>
+				<control type="progress">
+					<top>0</top>
+					<left>0</left>
+					<width>880</width>
+					<height>18</height>
+					<info>System.Memory(used.percent)</info>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>38</height>
+					<label>[COLOR grey2]$LOCALIZE[13271] [/COLOR]$INFO[System.CpuUsage]</label>
+					<font>font12</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>System.SupportsCPUUsage</visible>
+				</control>
+				<control type="progress">
+					<top>0</top>
+					<left>0</left>
+					<width>880</width>
+					<height>18</height>
+					<info>System.CpuUsage</info>
+				</control>
 			</control>
 		</control>
 	</controls>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -483,6 +483,22 @@ msgctxt "#31309"
 msgid "Memory used:"
 msgstr ""
 
+msgctxt "#31310"
+msgid "PVR"
+msgstr ""
+
+msgctxt "#31311"
+msgid "Player"
+msgstr ""
+
+msgctxt "#31312"
+msgid "Media"
+msgstr ""
+
+msgctxt "#31313"
+msgid "System"
+msgstr ""
+
 #empty strings from id 31310 to 31318
 
 msgctxt "#31319"
@@ -527,7 +543,63 @@ msgctxt "#31331"
 msgid "Album details"
 msgstr ""
 
-#empty strings from id 31332 to 31350
+msgctxt "#31332"
+msgid "Signal details"
+msgstr ""
+
+msgctxt "#31333"
+msgid "Video information"
+msgstr ""
+
+msgctxt "#31334"
+msgid "Audio information"
+msgstr ""
+
+msgctxt "#31335"
+msgid "Video resolution"
+msgstr ""
+
+msgctxt "#31336"
+msgid "Video bitrate"
+msgstr ""
+
+msgctxt "#31337"
+msgid "Audio bitrate"
+msgstr ""
+
+msgctxt "#31338"
+msgid "Audio channels"
+msgstr ""
+
+msgctxt "#31339"
+msgid "Audio language"
+msgstr ""
+
+msgctxt "#31340"
+msgid "Stream"
+msgstr ""
+
+msgctxt "#31341"
+msgid "Pixel format"
+msgstr ""
+
+msgctxt "#31342"
+msgid "Player cache"
+msgstr ""
+
+msgctxt "#31343"
+msgid "Screen resolution"
+msgstr ""
+
+msgctxt "#31344"
+msgid "Screen rendering speed"
+msgstr ""
+
+msgctxt "#31345"
+msgid "System temperature"
+msgstr ""
+
+#empty strings from id 31346 to 31350
 
 msgctxt "#31351"
 msgid "Pause"


### PR DESCRIPTION
Break player process up in a similar manner to Estuary which has tabs for each type of info

**Estuary Player Process**
![image](https://github.com/user-attachments/assets/ae6d7949-b741-467f-bea3-209cf6861d26)

# Current window

![image](https://github.com/user-attachments/assets/90ea49d4-932b-4ca7-b0a7-dd22109a6eee)

# Tab Style

I felt the Estuary style tab buttons wouldn't suit Confluence so after searching through Confluence I decided best fit would the style used for the submenus.

![image](https://github.com/user-attachments/assets/57f8eda7-a22c-497d-98c5-15eba394ebd3)

So the submenu **Files / Library / Add-ons** style.

# After

**Note -** the info shown in the **Media** tab was not shown in Confluence Player Process window before.

**PVR**
![image](https://github.com/user-attachments/assets/9427936f-c96e-4b82-986b-3823ec816e6f)

**Player**
![image](https://github.com/user-attachments/assets/de19016c-d80e-4b80-97cc-138003ff307d)

**Media**
![image](https://github.com/user-attachments/assets/775ef1c2-bc76-4586-b938-a8b6ffdd3640)
![image](https://github.com/user-attachments/assets/16edf632-ac8e-4fc4-87d1-0cbd8ecd605a)

**System**
![image](https://github.com/user-attachments/assets/a6ba5e85-0432-4ee4-b692-bf39b7c50b07)
